### PR TITLE
fixed classes bug

### DIFF
--- a/beautify-css.js
+++ b/beautify-css.js
@@ -143,7 +143,7 @@
         }
 
         // printer
-        var indentString = source_text.match(/^[\r\n]*[\t ]*/)[0];
+        var indentString = source_text.trim().match(/^[\r\n]*[\t ]*/)[0];
         var singleIndent = Array(indentSize + 1).join(indentCharacter);
         var indentLevel = 0;
 


### PR DESCRIPTION
It was adding a space between the colon and the CSS classes, for example **a:hover** was edited in **a: hover**.

I've made the fix just to make it works and use it for my job. It's not nice nor well thought. It just works.
Feel free to rethink the fix, just remember that you can't use the **peek()** function to test the first letter because it would match even not-css-classes but values.
