### PR TITLE
fix for html files formatting

### DIFF
--- a/beautify-css.js
+++ b/beautify-css.js
@@ -364,9 +364,17 @@
     /*global define */
     if (typeof define === "function") {
         // Add support for require.js
-        define(function (require, exports, module) {
-            exports.css_beautify = css_beautify;
-        });
+       if (typeof define.amd === "undefined") {
+            define(function(require, exports, module) {
+                exports.css_beautify = css_beautify;
+            });
+        } else {
+            // if is AMD ( https://github.com/amdjs/amdjs-api/wiki/AMD#defineamd-property- )
+            define([], function() {
+                return css_beautify;
+            });
+        }
+
     } else if (typeof exports !== "undefined") {
         // Add support for CommonJS. Just put this file somewhere on your require.paths
         // and you will be able to `var html_beautify = require("beautify").html_beautify`.

--- a/beautify-html.js
+++ b/beautify-html.js
@@ -808,7 +808,7 @@
 
     if (typeof define === "function") {
         // Add support for require.js
-        define([], function(js_beautify, css_beautify) {
+        define(["beautify", "beautify-css"], function(js_beautify, css_beautify) {
             return {
               html_beautify: function(html_source, options) {
                 return style_html(html_source, options, js_beautify, css_beautify);


### PR DESCRIPTION
beautify-css.js define is now matched beautify.js
Also seems like dependencies were lost in beautify-html.js
All this made html formatting work for me again. Can you please review it?

P.S. It's my first pull request, still learning some things, sorry if anything is wrong
