### PR TITLE
Updated JS Beautify, Improved Handlebars formatting, and fixed on save bug

### DIFF
--- a/main.js
+++ b/main.js
@@ -277,7 +277,7 @@ define(function (require, exports, module) {
     function onSave(event, doc) {
         var currentTimestamp = Date.now();
 
-        if (currentTimestamp === null || (currentTimestamp - localStorage.getItem(COMMAND_TIMESTAMP)) > 1000) {
+        if (currentTimestamp === undefined || (currentTimestamp - localStorage.getItem(COMMAND_TIMESTAMP)) > 1000) {
             format(true);
             localStorage.setItem(COMMAND_TIMESTAMP, currentTimestamp);
             CommandManager.execute(Commands.FILE_SAVE, {

--- a/main.js
+++ b/main.js
@@ -275,9 +275,11 @@ define(function (require, exports, module) {
 
 
     function onSave(event, doc) {
-        if ((event.timeStamp - localStorage.getItem(COMMAND_TIMESTAMP)) > 1000) {
+        var currentTimestamp = Date.now();
+
+        if ((currentTimestamp - localStorage.getItem(COMMAND_TIMESTAMP)) > 1000) {
             format(true);
-            localStorage.setItem(COMMAND_TIMESTAMP, event.timeStamp);
+            localStorage.setItem(COMMAND_TIMESTAMP, currentTimestamp);
             CommandManager.execute(Commands.FILE_SAVE, {
                 doc: doc
             });

--- a/main.js
+++ b/main.js
@@ -111,6 +111,23 @@ define(function (require, exports, module) {
      * @param {String} indentSize
      */
 
+    function _formatHandlebars(unformattedText, indentChar, indentSize) {
+        var options = {
+            indent_size: indentSize,
+            indent_char: indentChar,
+            indent_handlebars: true
+        };
+        var formattedText = html_beautify(unformattedText, $.extend(options, settings));
+        return formattedText;
+    }
+
+    /**
+     *
+     * @param {String} unformattedText
+     * @param {String} indentChar
+     * @param {String} indentSize
+     */
+
     function _formatCSS(unformattedText, indentChar, indentSize) {
         var formattedText = css_beautify(unformattedText, {
             indent_size: indentSize,
@@ -211,6 +228,11 @@ define(function (require, exports, module) {
         case 'javascript':
         case 'json':
             formattedText = _formatJavascript(unformattedText, indentChar, indentSize);
+            batchUpdate(formattedText, isSelection);
+            break;
+
+        case 'handlebars':
+            formattedText = _formatHandlebars(unformattedText, indentChar, indentSize);
             batchUpdate(formattedText, isSelection);
             break;
 

--- a/main.js
+++ b/main.js
@@ -277,7 +277,7 @@ define(function (require, exports, module) {
     function onSave(event, doc) {
         var currentTimestamp = Date.now();
 
-        if ((currentTimestamp - localStorage.getItem(COMMAND_TIMESTAMP)) > 1000) {
+        if (currentTimestamp === null || (currentTimestamp - localStorage.getItem(COMMAND_TIMESTAMP)) > 1000) {
             format(true);
             localStorage.setItem(COMMAND_TIMESTAMP, currentTimestamp);
             CommandManager.execute(Commands.FILE_SAVE, {


### PR DESCRIPTION
Now have three fixes here:
- Updated JS Beautify to v1.5.4, there were issues with ES6 Modules 'export default' that have been fixed in the newer version
- Fixed on save bug
- Set the indent_handlebars option for Handlebars templates. Now, works well with the Handlebars Syntax Highlighter extension.