### PR TITLE
Enable use of nested settings from .jsbeautifyrc.

### DIFF
--- a/main.js
+++ b/main.js
@@ -84,7 +84,8 @@ define(function (require, exports, module) {
             indent_size: indentSize,
             indent_char: indentChar
         };
-        var formattedText = js_beautify(unformattedText, $.extend(options, settings));
+        var jsSettings = settings.js || settings;
+        var formattedText = js_beautify(unformattedText, $.extend(options, jsSettings));
         return formattedText;
     }
 
@@ -100,7 +101,8 @@ define(function (require, exports, module) {
             indent_size: indentSize,
             indent_char: indentChar
         };
-        var formattedText = html_beautify(unformattedText, $.extend(options, settings));
+        var htmlSettings = settings.html || settings;
+        var formattedText = html_beautify(unformattedText, $.extend(options, htmlSettings));
         return formattedText;
     }
 
@@ -112,10 +114,12 @@ define(function (require, exports, module) {
      */
 
     function _formatCSS(unformattedText, indentChar, indentSize) {
-        var formattedText = css_beautify(unformattedText, {
+        var options = {
             indent_size: indentSize,
             indent_char: indentChar
-        });
+        };
+        var cssSettings = settings.css || settings;
+        var formattedText = css_beautify(unformattedText, $.extend(options, cssSettings));
         return formattedText;
     }
 


### PR DESCRIPTION
Brackets-beautify was not using settings from .jsbeautifyrc that were
nested inside html, css, or js properties. This update will use the
nested values if they are present and will use the top-level values
if no nested values are present.