### PR TITLE
Added a quick fix for php after "_formatHTML()"

### DIFF
--- a/main.js
+++ b/main.js
@@ -220,6 +220,9 @@ define(function (require, exports, module) {
         case 'ejs':
         case 'handlebars':
             formattedText = _formatHTML(unformattedText, indentChar, indentSize);
+            // for php files, "new" => "n ew", "array" => "a rray" after _formatHTML
+            formattedText = formattedText.replace("n ew", "new");
+            formattedText = formattedText.replace("a rray", "array");
             batchUpdate(formattedText, isSelection);
             break;
 

--- a/main.js
+++ b/main.js
@@ -220,9 +220,10 @@ define(function (require, exports, module) {
         case 'ejs':
         case 'handlebars':
             formattedText = _formatHTML(unformattedText, indentChar, indentSize);
-            // for php files, "new" => "n ew", "array" => "a rray" after _formatHTML
-            formattedText = formattedText.replace("n ew", "new");
-            formattedText = formattedText.replace("a rray", "array");
+            // for php files, remove unwanted white space ex. "= new" => "=n ew", "= array" => "=a rray" after _formatHTML
+            formattedText = formattedText.replace(/=. /g, function (a, b) {
+                return a.trim();
+            });
             batchUpdate(formattedText, isSelection);
             break;
 


### PR DESCRIPTION
Added a quick fix for _formatHTML returning "n ew", "a rray" instead of "new", "array" when applied to php files. It's a quick fix. More elegant solution might be needed.