### PR TITLE
Fixed "Code Folding" && beautify.js to v1.6.2

### DIFF
--- a/main.js
+++ b/main.js
@@ -172,14 +172,18 @@ define(function (require) {
             if (formattedText !== unformattedText) {
                 batchUpdate(formattedText, range);
             } else {
-                editor._codeMirror.undoSelection();
+                if (!autoSave) {
+                    editor._codeMirror.undoSelection();
+                }
             }
         } else {
             beautifiers[beautifier](unformattedText, currentOptions, function (formattedText) {
                 if (formattedText !== unformattedText) {
                     batchUpdate(formattedText, range);
                 } else {
-                    editor._codeMirror.undoSelection();
+                    if (!autoSave) {
+                        editor._codeMirror.undoSelection();
+                    }
                 }
             });
         }

--- a/main.js
+++ b/main.js
@@ -118,9 +118,11 @@ define(function (require) {
             currentOptions.indent_char = ' ';
         }
         var range;
-        if (editor.hasSelection()) {
+        var selectedText = editor.getSelectedText();
+        var fullText = document.getText();
+        if (editor.hasSelection() && selectedText !== fullText) {
             currentOptions.end_with_newline = false;
-            unformattedText = editor.getSelectedText();
+            unformattedText = selectedText;
             range = editor.getSelection();
 
             /*
@@ -137,7 +139,7 @@ define(function (require) {
                 unformattedText = indentChars + unformattedText;
             }
         } else {
-            unformattedText = document.getText();
+            unformattedText = fullText;
             /*
              * If the current document is html and is currently used in LiveDevelopment, we must not change the html tag
              * as that causes the DOM in the browser to duplicate (see https://github.com/adobe/brackets/issues/10634).

--- a/main.js
+++ b/main.js
@@ -62,8 +62,10 @@ define(function (require) {
         var document = DocumentManager.getCurrentDocument();
         document.batchOperation(function () {
             if (range) {
+                unfoldRange(editor._codeMirror, range);
                 document.replaceRange(formattedText, range.start, range.end);
             } else {
+                unfoldAll(editor._codeMirror);
                 document.setText(formattedText);
             }
             editor.setCursorPos(cursorPos);
@@ -227,6 +229,32 @@ define(function (require) {
     function executeCommand() {
         CommandManager.get(COMMAND_SAVE_ID).setChecked(!CommandManager.get(COMMAND_SAVE_ID).getChecked());
         prefs.set(PREF_SAVE_ID, CommandManager.get(COMMAND_SAVE_ID).getChecked());
+    }
+
+    function unfoldRange(cm, range) {
+        var from = range.start.line;
+        var to = range.end.line;
+        cm.operation(function () {
+            var i, e;
+            for (i = from, e = to; i <= e; i++) {
+                if (cm.isFolded(i)) {
+                    cm.unfoldCode(i, {range: cm._lineFolds[i]});
+                }
+            }
+        });
+    }
+
+    function unfoldAll(cm) {
+        var from = cm.firstLine();
+        var to = cm.lastLine();
+        cm.operation(function () {
+            var i, e;
+            for (i = from, e = to; i <= e; i++) {
+                if (cm.isFolded(i)) {
+                    cm.unfoldCode(i, {range: cm._lineFolds[i]});
+                }
+            }
+        });
     }
 
     prefs.definePreference(PREF_SAVE_ID, 'boolean', false, {

--- a/main.js
+++ b/main.js
@@ -171,11 +171,15 @@ define(function (require) {
             var formattedText = beautifiers[beautifier](unformattedText, currentOptions);
             if (formattedText !== unformattedText) {
                 batchUpdate(formattedText, range);
+            } else {
+                editor._codeMirror.undoSelection();
             }
         } else {
             beautifiers[beautifier](unformattedText, currentOptions, function (formattedText) {
                 if (formattedText !== unformattedText) {
                     batchUpdate(formattedText, range);
+                } else {
+                    editor._codeMirror.undoSelection();
                 }
             });
         }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "HTML",
         "SVG",
         "sass",
-        "scss",
+        "scss"
     ],
     "i18n": [
         "de",

--- a/thirdparty/beautify-css.js
+++ b/thirdparty/beautify-css.js
@@ -65,7 +65,7 @@
         options = options || {};
         source_text = source_text || '';
         // HACK: newline parsing inconsistent. This brute force normalizes the input.
-        source_text = source_text.replace(/\r\n|[\r\u2028\u2029]/g, '\n')
+        source_text = source_text.replace(/\r\n|[\r\u2028\u2029]/g, '\n');
 
         var indentSize = options.indent_size || 4;
         var indentCharacter = options.indent_char || ' ';
@@ -79,17 +79,16 @@
             indentSize = parseInt(indentSize, 10);
         }
 
-        if(options.indent_with_tabs){
+        if (options.indent_with_tabs) {
             indentCharacter = '\t';
             indentSize = 1;
         }
 
-        eol = eol.replace(/\\r/, '\r').replace(/\\n/, '\n')
+        eol = eol.replace(/\\r/, '\r').replace(/\\n/, '\n');
 
 
         // tokenizer
         var whiteRe = /^\s+$/;
-        var wordRe = /[\w$\-_]/;
 
         var pos = -1,
             ch;
@@ -189,7 +188,7 @@
                     // pseudoclasses can contain ()
                     openParen += 1;
                 } else if (ch === ')') {
-                    if (openParen == 0) {
+                    if (openParen === 0) {
                         return false;
                     }
                     openParen -= 1;
@@ -295,7 +294,7 @@
                     print.newLine(true);
                 }
             } else if (ch === '/' && peek() === '/') { // single line comment
-                if (!isAfterNewline && last_top_ch !== '{' ) {
+                if (!isAfterNewline && last_top_ch !== '{') {
                     print.trim();
                 }
                 print.singleSpace();
@@ -303,31 +302,37 @@
                 print.newLine();
             } else if (ch === '@') {
                 print.preserveSingleSpace();
-                output.push(ch);
 
-                // strip trailing space, if present, for hash property checks
-                var variableOrRule = peekString(": ,;{}()[]/='\"");
+                // deal with less propery mixins @{...}
+                if (peek() === '{') {
+                    output.push(eatString('}'));
+                } else {
+                    output.push(ch);
 
-                if (variableOrRule.match(/[ :]$/)) {
-                    // we have a variable or pseudo-class, add it and insert one space before continuing
-                    next();
-                    variableOrRule = eatString(": ").replace(/\s$/, '');
-                    output.push(variableOrRule);
-                    print.singleSpace();
-                }
+                    // strip trailing space, if present, for hash property checks
+                    var variableOrRule = peekString(": ,;{}()[]/='\"");
 
-                variableOrRule = variableOrRule.replace(/\s$/, '')
+                    if (variableOrRule.match(/[ :]$/)) {
+                        // we have a variable or pseudo-class, add it and insert one space before continuing
+                        next();
+                        variableOrRule = eatString(": ").replace(/\s$/, '');
+                        output.push(variableOrRule);
+                        print.singleSpace();
+                    }
 
-                // might be a nesting at-rule
-                if (variableOrRule in css_beautify.NESTED_AT_RULE) {
-                    nestedLevel += 1;
-                    if (variableOrRule in css_beautify.CONDITIONAL_GROUP_RULE) {
-                        enteringConditionalGroup = true;
+                    variableOrRule = variableOrRule.replace(/\s$/, '');
+
+                    // might be a nesting at-rule
+                    if (variableOrRule in css_beautify.NESTED_AT_RULE) {
+                        nestedLevel += 1;
+                        if (variableOrRule in css_beautify.CONDITIONAL_GROUP_RULE) {
+                            enteringConditionalGroup = true;
+                        }
                     }
                 }
             } else if (ch === '#' && peek() === '{') {
-              print.preserveSingleSpace();
-              output.push(eatString('}'));
+                print.preserveSingleSpace();
+                output.push(eatString('}'));
             } else if (ch === '{') {
                 if (peek(true) === '}') {
                     eatWhitespace();
@@ -423,7 +428,7 @@
                 print.preserveSingleSpace();
                 output.push(ch);
             } else if (ch === '=') { // no whitespace before or after
-                eatWhitespace()
+                eatWhitespace();
                 ch = '=';
                 output.push(ch);
             } else {
@@ -445,7 +450,7 @@
             sweetCode += '\n';
         }
 
-        if (eol != '\n') {
+        if (eol !== '\n') {
             sweetCode = sweetCode.replace(/[\n]/g, eol);
         }
 

--- a/thirdparty/beautify-html.js
+++ b/thirdparty/beautify-html.js
@@ -72,16 +72,16 @@
 
 (function() {
 
-    function trim(s) {
-        return s.replace(/^\s+|\s+$/g, '');
-    }
+    // function trim(s) {
+    //     return s.replace(/^\s+|\s+$/g, '');
+    // }
 
     function ltrim(s) {
         return s.replace(/^\s+/g, '');
     }
 
     function rtrim(s) {
-        return s.replace(/\s+$/g,'');
+        return s.replace(/\s+$/g, '');
     }
 
     function style_html(html_source, options, js_beautify, css_beautify) {
@@ -107,7 +107,7 @@
 
         // backwards compatibility to 1.3.4
         if ((options.wrap_line_length === undefined || parseInt(options.wrap_line_length, 10) === 0) &&
-                (options.max_char !== undefined && parseInt(options.max_char, 10) !== 0)) {
+            (options.max_char !== undefined && parseInt(options.max_char, 10) !== 0)) {
             options.wrap_line_length = options.max_char;
         }
 
@@ -115,7 +115,7 @@
         indent_size = (options.indent_size === undefined) ? 4 : parseInt(options.indent_size, 10);
         indent_character = (options.indent_char === undefined) ? ' ' : options.indent_char;
         brace_style = (options.brace_style === undefined) ? 'collapse' : options.brace_style;
-        wrap_line_length =  parseInt(options.wrap_line_length, 10) === 0 ? 32786 : parseInt(options.wrap_line_length || 250, 10);
+        wrap_line_length = parseInt(options.wrap_line_length, 10) === 0 ? 32786 : parseInt(options.wrap_line_length || 250, 10);
         unformatted = options.unformatted || [
             // https://www.w3.org/TR/html5/dom.html#phrasing-content
             'a', 'abbr', 'area', 'audio', 'b', 'bdi', 'bdo', 'br', 'button', 'canvas', 'cite',
@@ -131,23 +131,23 @@
         ];
         preserve_newlines = (options.preserve_newlines === undefined) ? true : options.preserve_newlines;
         max_preserve_newlines = preserve_newlines ?
-            (isNaN(parseInt(options.max_preserve_newlines, 10)) ? 32786 : parseInt(options.max_preserve_newlines, 10))
-            : 0;
+            (isNaN(parseInt(options.max_preserve_newlines, 10)) ? 32786 : parseInt(options.max_preserve_newlines, 10)) :
+            0;
         indent_handlebars = (options.indent_handlebars === undefined) ? false : options.indent_handlebars;
         wrap_attributes = (options.wrap_attributes === undefined) ? 'auto' : options.wrap_attributes;
         wrap_attributes_indent_size = (isNaN(parseInt(options.wrap_attributes_indent_size, 10))) ? indent_size : parseInt(options.wrap_attributes_indent_size, 10);
         end_with_newline = (options.end_with_newline === undefined) ? false : options.end_with_newline;
-        extra_liners = (typeof options.extra_liners == 'object') && options.extra_liners ?
+        extra_liners = (typeof options.extra_liners === 'object') && options.extra_liners ?
             options.extra_liners.concat() : (typeof options.extra_liners === 'string') ?
             options.extra_liners.split(',') : 'head,body,/html'.split(',');
         eol = options.eol ? options.eol : '\n';
 
-        if(options.indent_with_tabs){
+        if (options.indent_with_tabs) {
             indent_character = '\t';
             indent_size = 1;
         }
 
-        eol = eol.replace(/\\r/, '\r').replace(/\\n/, '\n')
+        eol = eol.replace(/\\r/, '\r').replace(/\\n/, '\n');
 
         function Parser() {
 
@@ -242,8 +242,7 @@
 
             this.get_content = function() { //function to capture regular content between tags
                 var input_char = '',
-                    content = [],
-                    space = false; //if a space is needed
+                    content = [];
 
                 while (this.input.charAt(this.pos) !== '<') {
                     if (this.pos >= this.input.length) {
@@ -285,7 +284,6 @@
                 if (this.pos === this.input.length) {
                     return ['', 'TK_EOF'];
                 }
-                var input_char = '';
                 var content = '';
                 var reg_match = new RegExp('</' + name + '\\s*>', 'igm');
                 reg_match.lastIndex = this.pos;
@@ -395,7 +393,7 @@
                         var wrapped = this.space_or_wrap(content);
                         var indentAttrs = wrapped && input_char !== '/' && wrap_attributes !== 'force';
                         space = false;
-                        if (!first_attr && wrap_attributes === 'force' &&  input_char !== '/') {
+                        if (!first_attr && wrap_attributes === 'force' && input_char !== '/') {
                             this.print_newline(false, content);
                             this.print_indentation(content);
                             indentAttrs = true;
@@ -407,10 +405,10 @@
                             }
                         }
                         for (var i = 0; i < content.length; i++) {
-                          if (content[i] === ' ') {
-                            first_attr = false;
-                            break;
-                          }
+                            if (content[i] === ' ') {
+                                first_attr = false;
+                                break;
+                            }
                         }
                     }
 
@@ -500,15 +498,15 @@
                     this.tag_type = 'SINGLE';
                 } else if (tag_check === 'script' &&
                     (tag_complete.search('type') === -1 ||
-                    (tag_complete.search('type') > -1 &&
-                    tag_complete.search(/\b(text|application)\/(x-)?(javascript|ecmascript|jscript|livescript|(ld\+)?json)/) > -1))) {
+                        (tag_complete.search('type') > -1 &&
+                            tag_complete.search(/\b(text|application)\/(x-)?(javascript|ecmascript|jscript|livescript|(ld\+)?json)/) > -1))) {
                     if (!peek) {
                         this.record_tag(tag_check);
                         this.tag_type = 'SCRIPT';
                     }
                 } else if (tag_check === 'style' &&
                     (tag_complete.search('type') === -1 ||
-                    (tag_complete.search('type') > -1 && tag_complete.search('text/css') > -1))) {
+                        (tag_complete.search('type') > -1 && tag_complete.search('text/css') > -1))) {
                     if (!peek) {
                         this.record_tag(tag_check);
                         this.tag_type = 'STYLE';
@@ -605,21 +603,21 @@
             };
 
             function tokenMatcher(delimiter) {
-              var token = '';
+                var token = '';
 
-              var add = function (str) {
-                var newToken = token + str.toLowerCase();
-                token = newToken.length <= delimiter.length ? newToken : newToken.substr(newToken.length - delimiter.length, delimiter.length);
-              };
+                var add = function(str) {
+                    var newToken = token + str.toLowerCase();
+                    token = newToken.length <= delimiter.length ? newToken : newToken.substr(newToken.length - delimiter.length, delimiter.length);
+                };
 
-              var doesNotMatch = function () {
-                return token.indexOf(delimiter) === -1;
-              };
+                var doesNotMatch = function() {
+                    return token.indexOf(delimiter) === -1;
+                };
 
-              return {
-                add: add,
-                doesNotMatch: doesNotMatch
-              };
+                return {
+                    add: add,
+                    doesNotMatch: doesNotMatch
+                };
             }
 
             this.get_unformatted = function(delimiter, orig_tag) { //function to return unformatted content in its entirety
@@ -745,7 +743,7 @@
                 this.input = js_source || ''; //gets the input for the Parser
 
                 // HACK: newline parsing inconsistent. This brute force normalizes the input.
-                this.input = this.input.replace(/\r\n|[\r\u2028\u2029]/g, '\n')
+                this.input = this.input.replace(/\r\n|[\r\u2028\u2029]/g, '\n');
 
                 this.output = [];
                 this.indent_character = indent_character;
@@ -888,9 +886,9 @@
                 case 'TK_TAG_HANDLEBARS_ELSE':
                     // Don't add a newline if opening {{#if}} tag is on the current line
                     var foundIfOnCurrentLine = false;
-                    for (var lastCheckedOutput=multi_parser.output.length-1; lastCheckedOutput>=0; lastCheckedOutput--) {
-		        if (multi_parser.output[lastCheckedOutput] === '\n') {
-		            break;
+                    for (var lastCheckedOutput = multi_parser.output.length - 1; lastCheckedOutput >= 0; lastCheckedOutput--) {
+                        if (multi_parser.output[lastCheckedOutput] === '\n') {
+                            break;
                         } else {
                             if (multi_parser.output[lastCheckedOutput].match(/{{#if/)) {
                                 foundIfOnCurrentLine = true;
@@ -979,7 +977,7 @@
             sweet_code += '\n';
         }
 
-        if (eol != '\n') {
+        if (eol !== '\n') {
             sweet_code = sweet_code.replace(/[\n]/g, eol);
         }
 
@@ -989,13 +987,13 @@
     if (typeof define === "function" && define.amd) {
         // Add support for AMD ( https://github.com/amdjs/amdjs-api/wiki/AMD#defineamd-property- )
         define(["require", "./beautify", "./beautify-css"], function(requireamd) {
-            var js_beautify =  requireamd("./beautify");
-            var css_beautify =  requireamd("./beautify-css");
+            var js_beautify = requireamd("./beautify");
+            var css_beautify = requireamd("./beautify-css");
 
             return {
-              html_beautify: function(html_source, options) {
-                return style_html(html_source, options, js_beautify.js_beautify, css_beautify.css_beautify);
-              }
+                html_beautify: function(html_source, options) {
+                    return style_html(html_source, options, js_beautify.js_beautify, css_beautify.css_beautify);
+                }
             };
         });
     } else if (typeof exports !== "undefined") {

--- a/thirdparty/beautify.js
+++ b/thirdparty/beautify.js
@@ -84,73 +84,93 @@
 
 */
 
+// Object.values polyfill found here:
+// http://tokenposts.blogspot.com.au/2012/04/javascript-objectkeys-browser.html
+if (!Object.values) {
+    Object.values = function(o) {
+        if (o !== Object(o)) {
+            throw new TypeError('Object.values called on a non-object');
+        }
+        var k = [],
+            p;
+        for (p in o) {
+            if (Object.prototype.hasOwnProperty.call(o, p)) {
+                k.push(o[p]);
+            }
+        }
+        return k;
+    };
+}
+
 (function() {
 
     var acorn = {};
-    (function (exports) {
-      // This section of code is taken from acorn.
-      //
-      // Acorn was written by Marijn Haverbeke and released under an MIT
-      // license. The Unicode regexps (for identifiers and whitespace) were
-      // taken from [Esprima](http://esprima.org) by Ariya Hidayat.
-      //
-      // Git repositories for Acorn are available at
-      //
-      //     http://marijnhaverbeke.nl/git/acorn
-      //     https://github.com/marijnh/acorn.git
+    (function(exports) {
+        /* jshint curly: false */
+        // This section of code is taken from acorn.
+        //
+        // Acorn was written by Marijn Haverbeke and released under an MIT
+        // license. The Unicode regexps (for identifiers and whitespace) were
+        // taken from [Esprima](http://esprima.org) by Ariya Hidayat.
+        //
+        // Git repositories for Acorn are available at
+        //
+        //     http://marijnhaverbeke.nl/git/acorn
+        //     https://github.com/marijnh/acorn.git
 
-      // ## Character categories
+        // ## Character categories
 
-      // Big ugly regular expressions that match characters in the
-      // whitespace, identifier, and identifier-start categories. These
-      // are only applied when a character is found to actually have a
-      // code point above 128.
+        // Big ugly regular expressions that match characters in the
+        // whitespace, identifier, and identifier-start categories. These
+        // are only applied when a character is found to actually have a
+        // code point above 128.
 
-      var nonASCIIwhitespace = /[\u1680\u180e\u2000-\u200a\u202f\u205f\u3000\ufeff]/;
-      var nonASCIIidentifierStartChars = "\xaa\xb5\xba\xc0-\xd6\xd8-\xf6\xf8-\u02c1\u02c6-\u02d1\u02e0-\u02e4\u02ec\u02ee\u0370-\u0374\u0376\u0377\u037a-\u037d\u0386\u0388-\u038a\u038c\u038e-\u03a1\u03a3-\u03f5\u03f7-\u0481\u048a-\u0527\u0531-\u0556\u0559\u0561-\u0587\u05d0-\u05ea\u05f0-\u05f2\u0620-\u064a\u066e\u066f\u0671-\u06d3\u06d5\u06e5\u06e6\u06ee\u06ef\u06fa-\u06fc\u06ff\u0710\u0712-\u072f\u074d-\u07a5\u07b1\u07ca-\u07ea\u07f4\u07f5\u07fa\u0800-\u0815\u081a\u0824\u0828\u0840-\u0858\u08a0\u08a2-\u08ac\u0904-\u0939\u093d\u0950\u0958-\u0961\u0971-\u0977\u0979-\u097f\u0985-\u098c\u098f\u0990\u0993-\u09a8\u09aa-\u09b0\u09b2\u09b6-\u09b9\u09bd\u09ce\u09dc\u09dd\u09df-\u09e1\u09f0\u09f1\u0a05-\u0a0a\u0a0f\u0a10\u0a13-\u0a28\u0a2a-\u0a30\u0a32\u0a33\u0a35\u0a36\u0a38\u0a39\u0a59-\u0a5c\u0a5e\u0a72-\u0a74\u0a85-\u0a8d\u0a8f-\u0a91\u0a93-\u0aa8\u0aaa-\u0ab0\u0ab2\u0ab3\u0ab5-\u0ab9\u0abd\u0ad0\u0ae0\u0ae1\u0b05-\u0b0c\u0b0f\u0b10\u0b13-\u0b28\u0b2a-\u0b30\u0b32\u0b33\u0b35-\u0b39\u0b3d\u0b5c\u0b5d\u0b5f-\u0b61\u0b71\u0b83\u0b85-\u0b8a\u0b8e-\u0b90\u0b92-\u0b95\u0b99\u0b9a\u0b9c\u0b9e\u0b9f\u0ba3\u0ba4\u0ba8-\u0baa\u0bae-\u0bb9\u0bd0\u0c05-\u0c0c\u0c0e-\u0c10\u0c12-\u0c28\u0c2a-\u0c33\u0c35-\u0c39\u0c3d\u0c58\u0c59\u0c60\u0c61\u0c85-\u0c8c\u0c8e-\u0c90\u0c92-\u0ca8\u0caa-\u0cb3\u0cb5-\u0cb9\u0cbd\u0cde\u0ce0\u0ce1\u0cf1\u0cf2\u0d05-\u0d0c\u0d0e-\u0d10\u0d12-\u0d3a\u0d3d\u0d4e\u0d60\u0d61\u0d7a-\u0d7f\u0d85-\u0d96\u0d9a-\u0db1\u0db3-\u0dbb\u0dbd\u0dc0-\u0dc6\u0e01-\u0e30\u0e32\u0e33\u0e40-\u0e46\u0e81\u0e82\u0e84\u0e87\u0e88\u0e8a\u0e8d\u0e94-\u0e97\u0e99-\u0e9f\u0ea1-\u0ea3\u0ea5\u0ea7\u0eaa\u0eab\u0ead-\u0eb0\u0eb2\u0eb3\u0ebd\u0ec0-\u0ec4\u0ec6\u0edc-\u0edf\u0f00\u0f40-\u0f47\u0f49-\u0f6c\u0f88-\u0f8c\u1000-\u102a\u103f\u1050-\u1055\u105a-\u105d\u1061\u1065\u1066\u106e-\u1070\u1075-\u1081\u108e\u10a0-\u10c5\u10c7\u10cd\u10d0-\u10fa\u10fc-\u1248\u124a-\u124d\u1250-\u1256\u1258\u125a-\u125d\u1260-\u1288\u128a-\u128d\u1290-\u12b0\u12b2-\u12b5\u12b8-\u12be\u12c0\u12c2-\u12c5\u12c8-\u12d6\u12d8-\u1310\u1312-\u1315\u1318-\u135a\u1380-\u138f\u13a0-\u13f4\u1401-\u166c\u166f-\u167f\u1681-\u169a\u16a0-\u16ea\u16ee-\u16f0\u1700-\u170c\u170e-\u1711\u1720-\u1731\u1740-\u1751\u1760-\u176c\u176e-\u1770\u1780-\u17b3\u17d7\u17dc\u1820-\u1877\u1880-\u18a8\u18aa\u18b0-\u18f5\u1900-\u191c\u1950-\u196d\u1970-\u1974\u1980-\u19ab\u19c1-\u19c7\u1a00-\u1a16\u1a20-\u1a54\u1aa7\u1b05-\u1b33\u1b45-\u1b4b\u1b83-\u1ba0\u1bae\u1baf\u1bba-\u1be5\u1c00-\u1c23\u1c4d-\u1c4f\u1c5a-\u1c7d\u1ce9-\u1cec\u1cee-\u1cf1\u1cf5\u1cf6\u1d00-\u1dbf\u1e00-\u1f15\u1f18-\u1f1d\u1f20-\u1f45\u1f48-\u1f4d\u1f50-\u1f57\u1f59\u1f5b\u1f5d\u1f5f-\u1f7d\u1f80-\u1fb4\u1fb6-\u1fbc\u1fbe\u1fc2-\u1fc4\u1fc6-\u1fcc\u1fd0-\u1fd3\u1fd6-\u1fdb\u1fe0-\u1fec\u1ff2-\u1ff4\u1ff6-\u1ffc\u2071\u207f\u2090-\u209c\u2102\u2107\u210a-\u2113\u2115\u2119-\u211d\u2124\u2126\u2128\u212a-\u212d\u212f-\u2139\u213c-\u213f\u2145-\u2149\u214e\u2160-\u2188\u2c00-\u2c2e\u2c30-\u2c5e\u2c60-\u2ce4\u2ceb-\u2cee\u2cf2\u2cf3\u2d00-\u2d25\u2d27\u2d2d\u2d30-\u2d67\u2d6f\u2d80-\u2d96\u2da0-\u2da6\u2da8-\u2dae\u2db0-\u2db6\u2db8-\u2dbe\u2dc0-\u2dc6\u2dc8-\u2dce\u2dd0-\u2dd6\u2dd8-\u2dde\u2e2f\u3005-\u3007\u3021-\u3029\u3031-\u3035\u3038-\u303c\u3041-\u3096\u309d-\u309f\u30a1-\u30fa\u30fc-\u30ff\u3105-\u312d\u3131-\u318e\u31a0-\u31ba\u31f0-\u31ff\u3400-\u4db5\u4e00-\u9fcc\ua000-\ua48c\ua4d0-\ua4fd\ua500-\ua60c\ua610-\ua61f\ua62a\ua62b\ua640-\ua66e\ua67f-\ua697\ua6a0-\ua6ef\ua717-\ua71f\ua722-\ua788\ua78b-\ua78e\ua790-\ua793\ua7a0-\ua7aa\ua7f8-\ua801\ua803-\ua805\ua807-\ua80a\ua80c-\ua822\ua840-\ua873\ua882-\ua8b3\ua8f2-\ua8f7\ua8fb\ua90a-\ua925\ua930-\ua946\ua960-\ua97c\ua984-\ua9b2\ua9cf\uaa00-\uaa28\uaa40-\uaa42\uaa44-\uaa4b\uaa60-\uaa76\uaa7a\uaa80-\uaaaf\uaab1\uaab5\uaab6\uaab9-\uaabd\uaac0\uaac2\uaadb-\uaadd\uaae0-\uaaea\uaaf2-\uaaf4\uab01-\uab06\uab09-\uab0e\uab11-\uab16\uab20-\uab26\uab28-\uab2e\uabc0-\uabe2\uac00-\ud7a3\ud7b0-\ud7c6\ud7cb-\ud7fb\uf900-\ufa6d\ufa70-\ufad9\ufb00-\ufb06\ufb13-\ufb17\ufb1d\ufb1f-\ufb28\ufb2a-\ufb36\ufb38-\ufb3c\ufb3e\ufb40\ufb41\ufb43\ufb44\ufb46-\ufbb1\ufbd3-\ufd3d\ufd50-\ufd8f\ufd92-\ufdc7\ufdf0-\ufdfb\ufe70-\ufe74\ufe76-\ufefc\uff21-\uff3a\uff41-\uff5a\uff66-\uffbe\uffc2-\uffc7\uffca-\uffcf\uffd2-\uffd7\uffda-\uffdc";
-      var nonASCIIidentifierChars = "\u0300-\u036f\u0483-\u0487\u0591-\u05bd\u05bf\u05c1\u05c2\u05c4\u05c5\u05c7\u0610-\u061a\u0620-\u0649\u0672-\u06d3\u06e7-\u06e8\u06fb-\u06fc\u0730-\u074a\u0800-\u0814\u081b-\u0823\u0825-\u0827\u0829-\u082d\u0840-\u0857\u08e4-\u08fe\u0900-\u0903\u093a-\u093c\u093e-\u094f\u0951-\u0957\u0962-\u0963\u0966-\u096f\u0981-\u0983\u09bc\u09be-\u09c4\u09c7\u09c8\u09d7\u09df-\u09e0\u0a01-\u0a03\u0a3c\u0a3e-\u0a42\u0a47\u0a48\u0a4b-\u0a4d\u0a51\u0a66-\u0a71\u0a75\u0a81-\u0a83\u0abc\u0abe-\u0ac5\u0ac7-\u0ac9\u0acb-\u0acd\u0ae2-\u0ae3\u0ae6-\u0aef\u0b01-\u0b03\u0b3c\u0b3e-\u0b44\u0b47\u0b48\u0b4b-\u0b4d\u0b56\u0b57\u0b5f-\u0b60\u0b66-\u0b6f\u0b82\u0bbe-\u0bc2\u0bc6-\u0bc8\u0bca-\u0bcd\u0bd7\u0be6-\u0bef\u0c01-\u0c03\u0c46-\u0c48\u0c4a-\u0c4d\u0c55\u0c56\u0c62-\u0c63\u0c66-\u0c6f\u0c82\u0c83\u0cbc\u0cbe-\u0cc4\u0cc6-\u0cc8\u0cca-\u0ccd\u0cd5\u0cd6\u0ce2-\u0ce3\u0ce6-\u0cef\u0d02\u0d03\u0d46-\u0d48\u0d57\u0d62-\u0d63\u0d66-\u0d6f\u0d82\u0d83\u0dca\u0dcf-\u0dd4\u0dd6\u0dd8-\u0ddf\u0df2\u0df3\u0e34-\u0e3a\u0e40-\u0e45\u0e50-\u0e59\u0eb4-\u0eb9\u0ec8-\u0ecd\u0ed0-\u0ed9\u0f18\u0f19\u0f20-\u0f29\u0f35\u0f37\u0f39\u0f41-\u0f47\u0f71-\u0f84\u0f86-\u0f87\u0f8d-\u0f97\u0f99-\u0fbc\u0fc6\u1000-\u1029\u1040-\u1049\u1067-\u106d\u1071-\u1074\u1082-\u108d\u108f-\u109d\u135d-\u135f\u170e-\u1710\u1720-\u1730\u1740-\u1750\u1772\u1773\u1780-\u17b2\u17dd\u17e0-\u17e9\u180b-\u180d\u1810-\u1819\u1920-\u192b\u1930-\u193b\u1951-\u196d\u19b0-\u19c0\u19c8-\u19c9\u19d0-\u19d9\u1a00-\u1a15\u1a20-\u1a53\u1a60-\u1a7c\u1a7f-\u1a89\u1a90-\u1a99\u1b46-\u1b4b\u1b50-\u1b59\u1b6b-\u1b73\u1bb0-\u1bb9\u1be6-\u1bf3\u1c00-\u1c22\u1c40-\u1c49\u1c5b-\u1c7d\u1cd0-\u1cd2\u1d00-\u1dbe\u1e01-\u1f15\u200c\u200d\u203f\u2040\u2054\u20d0-\u20dc\u20e1\u20e5-\u20f0\u2d81-\u2d96\u2de0-\u2dff\u3021-\u3028\u3099\u309a\ua640-\ua66d\ua674-\ua67d\ua69f\ua6f0-\ua6f1\ua7f8-\ua800\ua806\ua80b\ua823-\ua827\ua880-\ua881\ua8b4-\ua8c4\ua8d0-\ua8d9\ua8f3-\ua8f7\ua900-\ua909\ua926-\ua92d\ua930-\ua945\ua980-\ua983\ua9b3-\ua9c0\uaa00-\uaa27\uaa40-\uaa41\uaa4c-\uaa4d\uaa50-\uaa59\uaa7b\uaae0-\uaae9\uaaf2-\uaaf3\uabc0-\uabe1\uabec\uabed\uabf0-\uabf9\ufb20-\ufb28\ufe00-\ufe0f\ufe20-\ufe26\ufe33\ufe34\ufe4d-\ufe4f\uff10-\uff19\uff3f";
-      var nonASCIIidentifierStart = new RegExp("[" + nonASCIIidentifierStartChars + "]");
-      var nonASCIIidentifier = new RegExp("[" + nonASCIIidentifierStartChars + nonASCIIidentifierChars + "]");
+        var nonASCIIwhitespace = /[\u1680\u180e\u2000-\u200a\u202f\u205f\u3000\ufeff]/; // jshint ignore:line
+        var nonASCIIidentifierStartChars = "\xaa\xb5\xba\xc0-\xd6\xd8-\xf6\xf8-\u02c1\u02c6-\u02d1\u02e0-\u02e4\u02ec\u02ee\u0370-\u0374\u0376\u0377\u037a-\u037d\u0386\u0388-\u038a\u038c\u038e-\u03a1\u03a3-\u03f5\u03f7-\u0481\u048a-\u0527\u0531-\u0556\u0559\u0561-\u0587\u05d0-\u05ea\u05f0-\u05f2\u0620-\u064a\u066e\u066f\u0671-\u06d3\u06d5\u06e5\u06e6\u06ee\u06ef\u06fa-\u06fc\u06ff\u0710\u0712-\u072f\u074d-\u07a5\u07b1\u07ca-\u07ea\u07f4\u07f5\u07fa\u0800-\u0815\u081a\u0824\u0828\u0840-\u0858\u08a0\u08a2-\u08ac\u0904-\u0939\u093d\u0950\u0958-\u0961\u0971-\u0977\u0979-\u097f\u0985-\u098c\u098f\u0990\u0993-\u09a8\u09aa-\u09b0\u09b2\u09b6-\u09b9\u09bd\u09ce\u09dc\u09dd\u09df-\u09e1\u09f0\u09f1\u0a05-\u0a0a\u0a0f\u0a10\u0a13-\u0a28\u0a2a-\u0a30\u0a32\u0a33\u0a35\u0a36\u0a38\u0a39\u0a59-\u0a5c\u0a5e\u0a72-\u0a74\u0a85-\u0a8d\u0a8f-\u0a91\u0a93-\u0aa8\u0aaa-\u0ab0\u0ab2\u0ab3\u0ab5-\u0ab9\u0abd\u0ad0\u0ae0\u0ae1\u0b05-\u0b0c\u0b0f\u0b10\u0b13-\u0b28\u0b2a-\u0b30\u0b32\u0b33\u0b35-\u0b39\u0b3d\u0b5c\u0b5d\u0b5f-\u0b61\u0b71\u0b83\u0b85-\u0b8a\u0b8e-\u0b90\u0b92-\u0b95\u0b99\u0b9a\u0b9c\u0b9e\u0b9f\u0ba3\u0ba4\u0ba8-\u0baa\u0bae-\u0bb9\u0bd0\u0c05-\u0c0c\u0c0e-\u0c10\u0c12-\u0c28\u0c2a-\u0c33\u0c35-\u0c39\u0c3d\u0c58\u0c59\u0c60\u0c61\u0c85-\u0c8c\u0c8e-\u0c90\u0c92-\u0ca8\u0caa-\u0cb3\u0cb5-\u0cb9\u0cbd\u0cde\u0ce0\u0ce1\u0cf1\u0cf2\u0d05-\u0d0c\u0d0e-\u0d10\u0d12-\u0d3a\u0d3d\u0d4e\u0d60\u0d61\u0d7a-\u0d7f\u0d85-\u0d96\u0d9a-\u0db1\u0db3-\u0dbb\u0dbd\u0dc0-\u0dc6\u0e01-\u0e30\u0e32\u0e33\u0e40-\u0e46\u0e81\u0e82\u0e84\u0e87\u0e88\u0e8a\u0e8d\u0e94-\u0e97\u0e99-\u0e9f\u0ea1-\u0ea3\u0ea5\u0ea7\u0eaa\u0eab\u0ead-\u0eb0\u0eb2\u0eb3\u0ebd\u0ec0-\u0ec4\u0ec6\u0edc-\u0edf\u0f00\u0f40-\u0f47\u0f49-\u0f6c\u0f88-\u0f8c\u1000-\u102a\u103f\u1050-\u1055\u105a-\u105d\u1061\u1065\u1066\u106e-\u1070\u1075-\u1081\u108e\u10a0-\u10c5\u10c7\u10cd\u10d0-\u10fa\u10fc-\u1248\u124a-\u124d\u1250-\u1256\u1258\u125a-\u125d\u1260-\u1288\u128a-\u128d\u1290-\u12b0\u12b2-\u12b5\u12b8-\u12be\u12c0\u12c2-\u12c5\u12c8-\u12d6\u12d8-\u1310\u1312-\u1315\u1318-\u135a\u1380-\u138f\u13a0-\u13f4\u1401-\u166c\u166f-\u167f\u1681-\u169a\u16a0-\u16ea\u16ee-\u16f0\u1700-\u170c\u170e-\u1711\u1720-\u1731\u1740-\u1751\u1760-\u176c\u176e-\u1770\u1780-\u17b3\u17d7\u17dc\u1820-\u1877\u1880-\u18a8\u18aa\u18b0-\u18f5\u1900-\u191c\u1950-\u196d\u1970-\u1974\u1980-\u19ab\u19c1-\u19c7\u1a00-\u1a16\u1a20-\u1a54\u1aa7\u1b05-\u1b33\u1b45-\u1b4b\u1b83-\u1ba0\u1bae\u1baf\u1bba-\u1be5\u1c00-\u1c23\u1c4d-\u1c4f\u1c5a-\u1c7d\u1ce9-\u1cec\u1cee-\u1cf1\u1cf5\u1cf6\u1d00-\u1dbf\u1e00-\u1f15\u1f18-\u1f1d\u1f20-\u1f45\u1f48-\u1f4d\u1f50-\u1f57\u1f59\u1f5b\u1f5d\u1f5f-\u1f7d\u1f80-\u1fb4\u1fb6-\u1fbc\u1fbe\u1fc2-\u1fc4\u1fc6-\u1fcc\u1fd0-\u1fd3\u1fd6-\u1fdb\u1fe0-\u1fec\u1ff2-\u1ff4\u1ff6-\u1ffc\u2071\u207f\u2090-\u209c\u2102\u2107\u210a-\u2113\u2115\u2119-\u211d\u2124\u2126\u2128\u212a-\u212d\u212f-\u2139\u213c-\u213f\u2145-\u2149\u214e\u2160-\u2188\u2c00-\u2c2e\u2c30-\u2c5e\u2c60-\u2ce4\u2ceb-\u2cee\u2cf2\u2cf3\u2d00-\u2d25\u2d27\u2d2d\u2d30-\u2d67\u2d6f\u2d80-\u2d96\u2da0-\u2da6\u2da8-\u2dae\u2db0-\u2db6\u2db8-\u2dbe\u2dc0-\u2dc6\u2dc8-\u2dce\u2dd0-\u2dd6\u2dd8-\u2dde\u2e2f\u3005-\u3007\u3021-\u3029\u3031-\u3035\u3038-\u303c\u3041-\u3096\u309d-\u309f\u30a1-\u30fa\u30fc-\u30ff\u3105-\u312d\u3131-\u318e\u31a0-\u31ba\u31f0-\u31ff\u3400-\u4db5\u4e00-\u9fcc\ua000-\ua48c\ua4d0-\ua4fd\ua500-\ua60c\ua610-\ua61f\ua62a\ua62b\ua640-\ua66e\ua67f-\ua697\ua6a0-\ua6ef\ua717-\ua71f\ua722-\ua788\ua78b-\ua78e\ua790-\ua793\ua7a0-\ua7aa\ua7f8-\ua801\ua803-\ua805\ua807-\ua80a\ua80c-\ua822\ua840-\ua873\ua882-\ua8b3\ua8f2-\ua8f7\ua8fb\ua90a-\ua925\ua930-\ua946\ua960-\ua97c\ua984-\ua9b2\ua9cf\uaa00-\uaa28\uaa40-\uaa42\uaa44-\uaa4b\uaa60-\uaa76\uaa7a\uaa80-\uaaaf\uaab1\uaab5\uaab6\uaab9-\uaabd\uaac0\uaac2\uaadb-\uaadd\uaae0-\uaaea\uaaf2-\uaaf4\uab01-\uab06\uab09-\uab0e\uab11-\uab16\uab20-\uab26\uab28-\uab2e\uabc0-\uabe2\uac00-\ud7a3\ud7b0-\ud7c6\ud7cb-\ud7fb\uf900-\ufa6d\ufa70-\ufad9\ufb00-\ufb06\ufb13-\ufb17\ufb1d\ufb1f-\ufb28\ufb2a-\ufb36\ufb38-\ufb3c\ufb3e\ufb40\ufb41\ufb43\ufb44\ufb46-\ufbb1\ufbd3-\ufd3d\ufd50-\ufd8f\ufd92-\ufdc7\ufdf0-\ufdfb\ufe70-\ufe74\ufe76-\ufefc\uff21-\uff3a\uff41-\uff5a\uff66-\uffbe\uffc2-\uffc7\uffca-\uffcf\uffd2-\uffd7\uffda-\uffdc";
+        var nonASCIIidentifierChars = "\u0300-\u036f\u0483-\u0487\u0591-\u05bd\u05bf\u05c1\u05c2\u05c4\u05c5\u05c7\u0610-\u061a\u0620-\u0649\u0672-\u06d3\u06e7-\u06e8\u06fb-\u06fc\u0730-\u074a\u0800-\u0814\u081b-\u0823\u0825-\u0827\u0829-\u082d\u0840-\u0857\u08e4-\u08fe\u0900-\u0903\u093a-\u093c\u093e-\u094f\u0951-\u0957\u0962-\u0963\u0966-\u096f\u0981-\u0983\u09bc\u09be-\u09c4\u09c7\u09c8\u09d7\u09df-\u09e0\u0a01-\u0a03\u0a3c\u0a3e-\u0a42\u0a47\u0a48\u0a4b-\u0a4d\u0a51\u0a66-\u0a71\u0a75\u0a81-\u0a83\u0abc\u0abe-\u0ac5\u0ac7-\u0ac9\u0acb-\u0acd\u0ae2-\u0ae3\u0ae6-\u0aef\u0b01-\u0b03\u0b3c\u0b3e-\u0b44\u0b47\u0b48\u0b4b-\u0b4d\u0b56\u0b57\u0b5f-\u0b60\u0b66-\u0b6f\u0b82\u0bbe-\u0bc2\u0bc6-\u0bc8\u0bca-\u0bcd\u0bd7\u0be6-\u0bef\u0c01-\u0c03\u0c46-\u0c48\u0c4a-\u0c4d\u0c55\u0c56\u0c62-\u0c63\u0c66-\u0c6f\u0c82\u0c83\u0cbc\u0cbe-\u0cc4\u0cc6-\u0cc8\u0cca-\u0ccd\u0cd5\u0cd6\u0ce2-\u0ce3\u0ce6-\u0cef\u0d02\u0d03\u0d46-\u0d48\u0d57\u0d62-\u0d63\u0d66-\u0d6f\u0d82\u0d83\u0dca\u0dcf-\u0dd4\u0dd6\u0dd8-\u0ddf\u0df2\u0df3\u0e34-\u0e3a\u0e40-\u0e45\u0e50-\u0e59\u0eb4-\u0eb9\u0ec8-\u0ecd\u0ed0-\u0ed9\u0f18\u0f19\u0f20-\u0f29\u0f35\u0f37\u0f39\u0f41-\u0f47\u0f71-\u0f84\u0f86-\u0f87\u0f8d-\u0f97\u0f99-\u0fbc\u0fc6\u1000-\u1029\u1040-\u1049\u1067-\u106d\u1071-\u1074\u1082-\u108d\u108f-\u109d\u135d-\u135f\u170e-\u1710\u1720-\u1730\u1740-\u1750\u1772\u1773\u1780-\u17b2\u17dd\u17e0-\u17e9\u180b-\u180d\u1810-\u1819\u1920-\u192b\u1930-\u193b\u1951-\u196d\u19b0-\u19c0\u19c8-\u19c9\u19d0-\u19d9\u1a00-\u1a15\u1a20-\u1a53\u1a60-\u1a7c\u1a7f-\u1a89\u1a90-\u1a99\u1b46-\u1b4b\u1b50-\u1b59\u1b6b-\u1b73\u1bb0-\u1bb9\u1be6-\u1bf3\u1c00-\u1c22\u1c40-\u1c49\u1c5b-\u1c7d\u1cd0-\u1cd2\u1d00-\u1dbe\u1e01-\u1f15\u200c\u200d\u203f\u2040\u2054\u20d0-\u20dc\u20e1\u20e5-\u20f0\u2d81-\u2d96\u2de0-\u2dff\u3021-\u3028\u3099\u309a\ua640-\ua66d\ua674-\ua67d\ua69f\ua6f0-\ua6f1\ua7f8-\ua800\ua806\ua80b\ua823-\ua827\ua880-\ua881\ua8b4-\ua8c4\ua8d0-\ua8d9\ua8f3-\ua8f7\ua900-\ua909\ua926-\ua92d\ua930-\ua945\ua980-\ua983\ua9b3-\ua9c0\uaa00-\uaa27\uaa40-\uaa41\uaa4c-\uaa4d\uaa50-\uaa59\uaa7b\uaae0-\uaae9\uaaf2-\uaaf3\uabc0-\uabe1\uabec\uabed\uabf0-\uabf9\ufb20-\ufb28\ufe00-\ufe0f\ufe20-\ufe26\ufe33\ufe34\ufe4d-\ufe4f\uff10-\uff19\uff3f";
+        var nonASCIIidentifierStart = new RegExp("[" + nonASCIIidentifierStartChars + "]");
+        var nonASCIIidentifier = new RegExp("[" + nonASCIIidentifierStartChars + nonASCIIidentifierChars + "]");
 
-      // Whether a single character denotes a newline.
+        // Whether a single character denotes a newline.
 
-      var newline = exports.newline = /[\n\r\u2028\u2029]/;
+        exports.newline = /[\n\r\u2028\u2029]/;
 
-      // Matches a whole line break (where CRLF is considered a single
-      // line break). Used to count lines.
+        // Matches a whole line break (where CRLF is considered a single
+        // line break). Used to count lines.
 
-      // in javascript, these two differ
-      // in python they are the same, different methods are called on them
-      var lineBreak = exports.lineBreak = /\r\n|[\n\r\u2028\u2029]/;
-      var allLineBreaks = exports.allLineBreaks = new RegExp(lineBreak.source, 'g');
+        // in javascript, these two differ
+        // in python they are the same, different methods are called on them
+        exports.lineBreak = new RegExp('\r\n|' + exports.newline.source);
+        exports.allLineBreaks = new RegExp(exports.lineBreak.source, 'g');
 
 
-      // Test whether a given character code starts an identifier.
+        // Test whether a given character code starts an identifier.
 
-      var isIdentifierStart = exports.isIdentifierStart = function(code) {
-        // permit $ (36) and @ (64). @ is used in ES7 decorators.
-        if (code < 65) return code === 36 || code === 64;
-        // 65 through 91 are uppercase letters.
-        if (code < 91) return true;
-        // permit _ (95).
-        if (code < 97) return code === 95;
-        // 97 through 123 are lowercase letters.
-        if (code < 123)return true;
-        return code >= 0xaa && nonASCIIidentifierStart.test(String.fromCharCode(code));
-      };
+        exports.isIdentifierStart = function(code) {
+            // permit $ (36) and @ (64). @ is used in ES7 decorators.
+            if (code < 65) return code === 36 || code === 64;
+            // 65 through 91 are uppercase letters.
+            if (code < 91) return true;
+            // permit _ (95).
+            if (code < 97) return code === 95;
+            // 97 through 123 are lowercase letters.
+            if (code < 123) return true;
+            return code >= 0xaa && nonASCIIidentifierStart.test(String.fromCharCode(code));
+        };
 
-      // Test whether a given character is part of an identifier.
+        // Test whether a given character is part of an identifier.
 
-      var isIdentifierChar = exports.isIdentifierChar = function(code) {
-        if (code < 48) return code === 36;
-        if (code < 58) return true;
-        if (code < 65) return false;
-        if (code < 91) return true;
-        if (code < 97) return code === 95;
-        if (code < 123)return true;
-        return code >= 0xaa && nonASCIIidentifier.test(String.fromCharCode(code));
-      };
+        exports.isIdentifierChar = function(code) {
+            if (code < 48) return code === 36;
+            if (code < 58) return true;
+            if (code < 65) return false;
+            if (code < 91) return true;
+            if (code < 97) return code === 95;
+            if (code < 123) return true;
+            return code >= 0xaa && nonASCIIidentifier.test(String.fromCharCode(code));
+        };
     })(acorn);
+    /* jshint curly: true */
 
     function in_array(what, arr) {
         for (var i = 0; i < arr.length; i += 1) {
@@ -169,9 +189,9 @@
         return s.replace(/^\s+/g, '');
     }
 
-    function rtrim(s) {
-        return s.replace(/\s+$/g, '');
-    }
+    // function rtrim(s) {
+    //     return s.replace(/\s+$/g, '');
+    // }
 
     function js_beautify(js_source_text, options) {
         "use strict";
@@ -179,20 +199,43 @@
         return beautifier.beautify();
     }
 
+    function sanitizeOperatorPosition(opPosition) {
+        opPosition = opPosition || OPERATOR_POSITION.before_newline;
+
+        var validPositionValues = Object.values(OPERATOR_POSITION);
+
+        if (!in_array(opPosition, validPositionValues)) {
+            throw new Error("Invalid Option Value: The option 'operator_position' must be one of the following values\n" +
+                validPositionValues +
+                "\nYou passed in: '" + opPosition + "'");
+        }
+
+        return opPosition;
+    }
+
+    var OPERATOR_POSITION = {
+        before_newline: 'before-newline',
+        after_newline: 'after-newline',
+        preserve_newline: 'preserve-newline',
+    };
+
+    var OPERATOR_POSITION_BEFORE_OR_PRESERVE = [OPERATOR_POSITION.before_newline, OPERATOR_POSITION.preserve_newline];
+
     var MODE = {
-            BlockStatement: 'BlockStatement', // 'BLOCK'
-            Statement: 'Statement', // 'STATEMENT'
-            ObjectLiteral: 'ObjectLiteral', // 'OBJECT',
-            ArrayLiteral: 'ArrayLiteral', //'[EXPRESSION]',
-            ForInitializer: 'ForInitializer', //'(FOR-EXPRESSION)',
-            Conditional: 'Conditional', //'(COND-EXPRESSION)',
-            Expression: 'Expression' //'(EXPRESSION)'
-        };
+        BlockStatement: 'BlockStatement', // 'BLOCK'
+        Statement: 'Statement', // 'STATEMENT'
+        ObjectLiteral: 'ObjectLiteral', // 'OBJECT',
+        ArrayLiteral: 'ArrayLiteral', //'[EXPRESSION]',
+        ForInitializer: 'ForInitializer', //'(FOR-EXPRESSION)',
+        Conditional: 'Conditional', //'(COND-EXPRESSION)',
+        Expression: 'Expression' //'(EXPRESSION)'
+    };
 
     function Beautifier(js_source_text, options) {
         "use strict";
-        var output
-        var tokens = [], token_pos;
+        var output;
+        var tokens = [],
+            token_pos;
         var Tokenizer;
         var current_token;
         var last_type, last_last_text, indent_string;
@@ -244,6 +287,7 @@
                 else_block: false,
                 do_block: false,
                 do_while: false,
+                import_block: false,
                 in_case_statement: false, // switch(..){ INSIDE HERE }
                 in_case: false, // we're on the exact line with "case 0:"
                 case_body: false, // the indented case-action block
@@ -287,16 +331,17 @@
         opt.e4x = (options.e4x === undefined) ? false : options.e4x;
         opt.end_with_newline = (options.end_with_newline === undefined) ? false : options.end_with_newline;
         opt.comma_first = (options.comma_first === undefined) ? false : options.comma_first;
+        opt.operator_position = sanitizeOperatorPosition(options.operator_position);
 
         // For testing of beautify ignore:start directive
         opt.test_output_raw = (options.test_output_raw === undefined) ? false : options.test_output_raw;
 
         // force opt.space_after_anon_function to true if opt.jslint_happy
-        if(opt.jslint_happy) {
+        if (opt.jslint_happy) {
             opt.space_after_anon_function = true;
         }
 
-        if(options.indent_with_tabs){
+        if (options.indent_with_tabs) {
             opt.indent_char = '\t';
             opt.indent_size = 1;
         }
@@ -308,7 +353,7 @@
             }
         }
 
-        opt.eol = opt.eol.replace(/\\r/, '\r').replace(/\\n/, '\n')
+        opt.eol = opt.eol.replace(/\\r/, '\r').replace(/\\n/, '\n');
 
         //----------------------------------
         indent_string = '';
@@ -318,8 +363,8 @@
         }
 
         var preindent_index = 0;
-        if(js_source_text && js_source_text.length) {
-            while ( (js_source_text.charAt(preindent_index) === ' ' ||
+        if (js_source_text && js_source_text.length) {
+            while ((js_source_text.charAt(preindent_index) === ' ' ||
                     js_source_text.charAt(preindent_index) === '\t')) {
                 baseIndentString += js_source_text.charAt(preindent_index);
                 preindent_index += 1;
@@ -356,8 +401,13 @@
             tokens = Tokenizer.tokenize();
             token_pos = 0;
 
-            while (local_token = get_token()) {
-                for(var i = 0; i < local_token.comments_before.length; i++) {
+            function get_local_token() {
+                local_token = get_token();
+                return local_token;
+            }
+
+            while (get_local_token()) {
+                for (var i = 0; i < local_token.comments_before.length; i++) {
                     // The cleanest handling of inline comments is to treat them as though they aren't there.
                     // Just continue formatting and the behavior should be logical.
                     // Also ignore unknown tokens.  Again, this should result in better behavior.
@@ -377,7 +427,7 @@
                 sweet_code += '\n';
             }
 
-            if (opt.eol != '\n') {
+            if (opt.eol !== '\n') {
                 sweet_code = sweet_code.replace(/[\n]/g, opt.eol);
             }
 
@@ -389,7 +439,7 @@
             var keep_whitespace = opt.keep_array_indentation && is_array(flags.mode);
 
             if (keep_whitespace) {
-                for (i = 0; i < newlines; i += 1) {
+                for (var i = 0; i < newlines; i += 1) {
                     print_newline(i > 0);
                 }
             } else {
@@ -400,7 +450,7 @@
                 if (opt.preserve_newlines) {
                     if (local_token.newlines > 1) {
                         print_newline();
-                        for (var i = 1; i < newlines; i += 1) {
+                        for (var j = 1; j < newlines; j += 1) {
                             print_newline(true);
                         }
                     }
@@ -430,22 +480,35 @@
             return out;
         }
 
-        var newline_restricted_tokens = ['break','contiue','return', 'throw'];
+        var newline_restricted_tokens = ['break', 'contiue', 'return', 'throw'];
+
         function allow_wrap_or_preserved_newline(force_linewrap) {
             force_linewrap = (force_linewrap === undefined) ? false : force_linewrap;
 
             // Never wrap the first token on a line
             if (output.just_added_newline()) {
-                return
+                return;
             }
 
-            if ((opt.preserve_newlines && current_token.wanted_newline) || force_linewrap) {
+            var shouldPreserveOrForce = (opt.preserve_newlines && current_token.wanted_newline) || force_linewrap;
+            var operatorLogicApplies = in_array(flags.last_text, Tokenizer.positionable_operators) || in_array(current_token.text, Tokenizer.positionable_operators);
+
+            if (operatorLogicApplies) {
+                var shouldPrintOperatorNewline = (
+                        in_array(flags.last_text, Tokenizer.positionable_operators) &&
+                        in_array(opt.operator_position, OPERATOR_POSITION_BEFORE_OR_PRESERVE)
+                    ) ||
+                    in_array(current_token.text, Tokenizer.positionable_operators);
+                shouldPreserveOrForce = shouldPreserveOrForce && shouldPrintOperatorNewline;
+            }
+
+            if (shouldPreserveOrForce) {
                 print_newline(false, true);
             } else if (opt.wrap_line_length) {
                 if (last_type === 'TK_RESERVED' && in_array(flags.last_text, newline_restricted_tokens)) {
                     // These tokens should never have a newline inserted
                     // between them and the following expression.
-                    return
+                    return;
                 }
                 var proposed_line_length = output.current_line.get_character_count() + current_token.text.length +
                     (output.space_before_token ? 1 : 0);
@@ -482,21 +545,21 @@
 
         function print_token(printable_token) {
             if (output.raw) {
-                output.add_raw_token(current_token)
+                output.add_raw_token(current_token);
                 return;
             }
 
-            if (opt.comma_first && last_type === 'TK_COMMA'
-                && output.just_added_newline()) {
-                if(output.previous_line.last() === ',') {
+            if (opt.comma_first && last_type === 'TK_COMMA' &&
+                output.just_added_newline()) {
+                if (output.previous_line.last() === ',') {
                     var popped = output.previous_line.pop();
                     // if the comma was already at the start of the line,
                     // pull back onto that line and reprint the indentation
-                    if(output.previous_line.is_empty()) {
-                         output.previous_line.push(popped);
-                         output.trim(true);
-                         output.current_line.pop();
-                         output.trim();
+                    if (output.previous_line.is_empty()) {
+                        output.previous_line.push(popped);
+                        output.trim(true);
+                        output.current_line.pop();
+                        output.trim();
                     }
 
                     // add the comma in front of the next token
@@ -517,8 +580,10 @@
 
         function deindent() {
             if (flags.indentation_level > 0 &&
-                ((!flags.parent) || flags.indentation_level > flags.parent.indentation_level))
+                ((!flags.parent) || flags.indentation_level > flags.parent.indentation_level)) {
                 flags.indentation_level -= 1;
+
+            }
         }
 
         function set_mode(mode) {
@@ -557,19 +622,19 @@
 
         function start_of_statement() {
             if (
-                    (last_type === 'TK_RESERVED' && in_array(flags.last_text, ['var', 'let', 'const']) && current_token.type === 'TK_WORD') ||
-                    (last_type === 'TK_RESERVED' && flags.last_text === 'do') ||
-                    (last_type === 'TK_RESERVED' && in_array(flags.last_text, ['return', 'throw']) && !current_token.wanted_newline) ||
-                    (last_type === 'TK_RESERVED' && flags.last_text === 'else' && !(current_token.type === 'TK_RESERVED' && current_token.text === 'if')) ||
-                    (last_type === 'TK_END_EXPR' && (previous_flags.mode === MODE.ForInitializer || previous_flags.mode === MODE.Conditional)) ||
-                    (last_type === 'TK_WORD' && flags.mode === MODE.BlockStatement
-                        && !flags.in_case
-                        && !(current_token.text === '--' || current_token.text === '++')
-                        && last_last_text !== 'function'
-                        && current_token.type !== 'TK_WORD' && current_token.type !== 'TK_RESERVED') ||
-                    (flags.mode === MODE.ObjectLiteral && (
-                        (flags.last_text === ':' && flags.ternary_depth === 0) || (last_type === 'TK_RESERVED' && in_array(flags.last_text, ['get', 'set']))))
-                ) {
+                (last_type === 'TK_RESERVED' && in_array(flags.last_text, ['var', 'let', 'const']) && current_token.type === 'TK_WORD') ||
+                (last_type === 'TK_RESERVED' && flags.last_text === 'do') ||
+                (last_type === 'TK_RESERVED' && in_array(flags.last_text, ['return', 'throw']) && !current_token.wanted_newline) ||
+                (last_type === 'TK_RESERVED' && flags.last_text === 'else' && !(current_token.type === 'TK_RESERVED' && current_token.text === 'if')) ||
+                (last_type === 'TK_END_EXPR' && (previous_flags.mode === MODE.ForInitializer || previous_flags.mode === MODE.Conditional)) ||
+                (last_type === 'TK_WORD' && flags.mode === MODE.BlockStatement &&
+                    !flags.in_case &&
+                    !(current_token.text === '--' || current_token.text === '++') &&
+                    last_last_text !== 'function' &&
+                    current_token.type !== 'TK_WORD' && current_token.type !== 'TK_RESERVED') ||
+                (flags.mode === MODE.ObjectLiteral && (
+                    (flags.last_text === ':' && flags.ternary_depth === 0) || (last_type === 'TK_RESERVED' && in_array(flags.last_text, ['get', 'set']))))
+            ) {
 
                 set_mode(MODE.Statement);
                 indent();
@@ -690,7 +755,7 @@
             }
 
             // Should be a space between await and an IIFE
-            if(current_token.text === '(' && last_type === 'TK_RESERVED' && flags.last_word === 'await'){
+            if (current_token.text === '(' && last_type === 'TK_RESERVED' && flags.last_word === 'await') {
                 output.space_before_token = true;
             }
 
@@ -735,7 +800,7 @@
             }
 
             if (opt.space_in_paren) {
-                if (last_type === 'TK_START_EXPR' && ! opt.space_in_empty_paren) {
+                if (last_type === 'TK_START_EXPR' && !opt.space_in_empty_paren) {
                     // () [] no inner space in empty parens like these, ever, ref #320
                     output.trim();
                     output.space_before_token = false;
@@ -763,15 +828,15 @@
 
         function handle_start_block() {
             // Check if this is should be treated as a ObjectLiteral
-            var next_token = get_token(1)
-            var second_token = get_token(2)
+            var next_token = get_token(1);
+            var second_token = get_token(2);
             if (second_token && (
-                    (in_array(second_token.text, [':', ',']) && in_array(next_token.type, ['TK_STRING', 'TK_WORD', 'TK_RESERVED']))
-                    || (in_array(next_token.text, ['get', 'set']) && in_array(second_token.type, ['TK_WORD', 'TK_RESERVED']))
+                    (in_array(second_token.text, [':', ',']) && in_array(next_token.type, ['TK_STRING', 'TK_WORD', 'TK_RESERVED'])) ||
+                    (in_array(next_token.text, ['get', 'set']) && in_array(second_token.type, ['TK_WORD', 'TK_RESERVED']))
                 )) {
                 // We don't support TypeScript,but we didn't break it for a very long time.
                 // We'll try to keep not breaking it.
-                if (!in_array(last_last_text, ['class','interface'])) {
+                if (!in_array(last_last_text, ['class', 'interface'])) {
                     set_mode(MODE.ObjectLiteral);
                 } else {
                     set_mode(MODE.BlockStatement);
@@ -781,7 +846,7 @@
                 set_mode(MODE.BlockStatement);
             } else if (in_array(last_type, ['TK_EQUALS', 'TK_START_EXPR', 'TK_COMMA', 'TK_OPERATOR']) ||
                 (last_type === 'TK_RESERVED' && in_array(flags.last_text, ['return', 'throw', 'import']))
-                ) {
+            ) {
                 // Detecting shorthand function syntax is difficult by scanning forward,
                 //     so check the surrounding context.
                 // If the block is being returned, imported, passed as arg,
@@ -791,7 +856,7 @@
                 set_mode(MODE.BlockStatement);
             }
 
-            var empty_braces = !next_token.comments_before.length &&  next_token.text === '}';
+            var empty_braces = !next_token.comments_before.length && next_token.text === '}';
             var empty_anonymous_function = empty_braces && flags.last_word === 'function' &&
                 last_type === 'TK_END_EXPR';
 
@@ -820,19 +885,21 @@
                             break;
                         }
                     } while (check_token.type !== 'TK_EOF' &&
-                          !(check_token.type === 'TK_END_BLOCK' && check_token.opened === current_token))
+                        !(check_token.type === 'TK_END_BLOCK' && check_token.opened === current_token));
                 }
 
                 if (is_array(previous_flags.mode) && (last_type === 'TK_START_EXPR' || last_type === 'TK_COMMA')) {
                     // if we're preserving inline,
                     // allow newline between comma and next brace.
-                    if (flags.inline_frame) {
+                    if (last_type === 'TK_COMMA' || opt.space_in_paren) {
+                        output.space_before_token = true;
+                    }
+
+                    if (opt.brace_style === 'collapse-preserve-inline' &&
+                        (last_type === 'TK_COMMA' || (last_type === 'TK_START_EXPR' && flags.inline_frame))) {
                         allow_wrap_or_preserved_newline();
-                        flags.inline_frame = true;
                         previous_flags.multiline_frame = previous_flags.multiline_frame || flags.multiline_frame;
                         flags.multiline_frame = false;
-                    } else {
-                        output.space_before_token = last_type === 'TK_COMMA';
                     }
                 } else if (last_type !== 'TK_OPERATOR' && last_type !== 'TK_START_EXPR') {
                     if (last_type === 'TK_START_BLOCK') {
@@ -878,15 +945,16 @@
         }
 
         function handle_word() {
-            if (current_token.type === 'TK_RESERVED' && flags.mode !== MODE.ObjectLiteral &&
-                in_array(current_token.text, ['set', 'get'])) {
-                current_token.type = 'TK_WORD';
-            }
-
-            if (current_token.type === 'TK_RESERVED' && flags.mode === MODE.ObjectLiteral) {
-                var next_token = get_token(1);
-                if (next_token.text == ':') {
+            if (current_token.type === 'TK_RESERVED') {
+                if (in_array(current_token.text, ['set', 'get']) && flags.mode !== MODE.ObjectLiteral) {
                     current_token.type = 'TK_WORD';
+                } else if (in_array(current_token.text, ['as', 'from']) && !flags.import_block) {
+                    current_token.type = 'TK_WORD';
+                } else if (flags.mode === MODE.ObjectLiteral) {
+                    var next_token = get_token(1);
+                    if (next_token.text === ':') {
+                        current_token.type = 'TK_WORD';
+                    }
                 }
             }
 
@@ -945,10 +1013,10 @@
             }
 
             if (current_token.type === 'TK_RESERVED' && current_token.text === 'function') {
-                if (in_array(flags.last_text, ['}', ';']) || (output.just_added_newline() && ! in_array(flags.last_text, ['[', '{', ':', '=', ',']))) {
+                if (in_array(flags.last_text, ['}', ';']) || (output.just_added_newline() && !in_array(flags.last_text, ['[', '{', ':', '=', ',']))) {
                     // make sure there is a nice clean space of at least one blank line
                     // before a new function definition
-                    if ( !output.just_added_blankline() && !current_token.comments_before.length) {
+                    if (!output.just_added_blankline() && !current_token.comments_before.length) {
                         print_newline();
                         print_newline(true);
                     }
@@ -977,7 +1045,7 @@
                 }
             }
 
-            if (current_token.type === 'TK_RESERVED' &&  in_array(current_token.text, ['function', 'get', 'set'])) {
+            if (current_token.type === 'TK_RESERVED' && in_array(current_token.text, ['function', 'get', 'set'])) {
                 print_token();
                 flags.last_word = current_token.text;
                 return;
@@ -1070,12 +1138,16 @@
             print_token();
             flags.last_word = current_token.text;
 
-            if (current_token.type === 'TK_RESERVED' && current_token.text === 'do') {
-                flags.do_block = true;
-            }
-
-            if (current_token.type === 'TK_RESERVED' && current_token.text === 'if') {
-                flags.if_block = true;
+            if (current_token.type === 'TK_RESERVED') {
+                if (current_token.text === 'do') {
+                    flags.do_block = true;
+                } else if (current_token.text === 'if') {
+                    flags.if_block = true;
+                } else if (current_token.text === 'import') {
+                    flags.import_block = true;
+                } else if (flags.import_block && current_token.type === 'TK_RESERVED' && current_token.text === 'from') {
+                    flags.import_block = false;
+                }
             }
         }
 
@@ -1087,6 +1159,11 @@
             }
             while (flags.mode === MODE.Statement && !flags.if_block && !flags.do_block) {
                 restore_mode();
+            }
+
+            // hacky but effective for the moment
+            if (flags.import_block) {
+                flags.import_block = false;
             }
             print_token();
         }
@@ -1174,6 +1251,18 @@
                 return;
             }
 
+            if (current_token.text === '::') {
+                // no spaces around exotic namespacing syntax operator
+                print_token();
+                return;
+            }
+
+            // Allow line wrapping between operators when operator_position is
+            //   set to before or preserve
+            if (last_type === 'TK_OPERATOR' && in_array(opt.operator_position, OPERATOR_POSITION_BEFORE_OR_PRESERVE)) {
+                allow_wrap_or_preserved_newline();
+            }
+
             if (current_token.text === ':' && flags.in_case) {
                 flags.case_body = true;
                 indent();
@@ -1183,21 +1272,86 @@
                 return;
             }
 
-            if (current_token.text === '::') {
-                // no spaces around exotic namespacing syntax operator
-                print_token();
-                return;
-            }
-
-            // Allow line wrapping between operators
-            if (last_type === 'TK_OPERATOR') {
-                allow_wrap_or_preserved_newline();
-            }
-
             var space_before = true;
             var space_after = true;
+            var in_ternary = false;
+            var isGeneratorAsterisk = current_token.text === '*' && last_type === 'TK_RESERVED' && flags.last_text === 'function';
+            var isUnary = in_array(current_token.text, ['-', '+']) && (
+                in_array(last_type, ['TK_START_BLOCK', 'TK_START_EXPR', 'TK_EQUALS', 'TK_OPERATOR']) ||
+                in_array(flags.last_text, Tokenizer.line_starters) ||
+                flags.last_text === ','
+            );
 
-            if (in_array(current_token.text, ['--', '++', '!', '~']) || (in_array(current_token.text, ['-', '+']) && (in_array(last_type, ['TK_START_BLOCK', 'TK_START_EXPR', 'TK_EQUALS', 'TK_OPERATOR']) || in_array(flags.last_text, Tokenizer.line_starters) || flags.last_text === ','))) {
+            if (current_token.text === ':') {
+                if (flags.ternary_depth === 0) {
+                    // Colon is invalid javascript outside of ternary and object, but do our best to guess what was meant.
+                    space_before = false;
+                } else {
+                    flags.ternary_depth -= 1;
+                    in_ternary = true;
+                }
+            } else if (current_token.text === '?') {
+                flags.ternary_depth += 1;
+            }
+
+            // let's handle the operator_position option prior to any conflicting logic
+            if (!isUnary && !isGeneratorAsterisk && opt.preserve_newlines && in_array(current_token.text, Tokenizer.positionable_operators)) {
+                var isColon = current_token.text === ':';
+                var isTernaryColon = (isColon && in_ternary);
+                var isOtherColon = (isColon && !in_ternary);
+
+                switch (opt.operator_position) {
+                    case OPERATOR_POSITION.before_newline:
+                        // if the current token is : and it's not a ternary statement then we set space_before to false
+                        output.space_before_token = !isOtherColon;
+
+                        print_token();
+
+                        if (!isColon || isTernaryColon) {
+                            allow_wrap_or_preserved_newline();
+                        }
+
+                        output.space_before_token = true;
+                        return;
+
+                    case OPERATOR_POSITION.after_newline:
+                        // if the current token is anything but colon, or (via deduction) it's a colon and in a ternary statement,
+                        //   then print a newline.
+
+                        output.space_before_token = true;
+
+                        if (!isColon || isTernaryColon) {
+                            if (get_token(1).wanted_newline) {
+                                print_newline(false, true);
+                            } else {
+                                allow_wrap_or_preserved_newline();
+                            }
+                        } else {
+                            output.space_before_token = false;
+                        }
+
+                        print_token();
+
+                        output.space_before_token = true;
+                        return;
+
+                    case OPERATOR_POSITION.preserve_newline:
+                        if (!isOtherColon) {
+                            allow_wrap_or_preserved_newline();
+                        }
+
+                        // if we just added a newline, or the current token is : and it's not a ternary statement,
+                        //   then we set space_before to false
+                        space_before = !(output.just_added_newline() || isOtherColon);
+
+                        output.space_before_token = space_before;
+                        print_token();
+                        output.space_before_token = true;
+                        return;
+                }
+            }
+
+            if (in_array(current_token.text, ['--', '++', '!', '~']) || isUnary) {
                 // unary operators (and binary +/- pretending to be unary) special cases
 
                 space_before = false;
@@ -1233,22 +1387,13 @@
                 }
 
 
-                if (((flags.mode === MODE.BlockStatement && !flags.inline_frame) || flags.mode === MODE.Statement)
-                    && (flags.last_text === '{' || flags.last_text === ';')) {
+                if (((flags.mode === MODE.BlockStatement && !flags.inline_frame) || flags.mode === MODE.Statement) &&
+                    (flags.last_text === '{' || flags.last_text === ';')) {
                     // { foo; --i }
                     // foo(); --bar;
                     print_newline();
                 }
-            } else if (current_token.text === ':') {
-                if (flags.ternary_depth === 0) {
-                    // Colon is invalid javascript outside of ternary and object, but do our best to guess what was meant.
-                    space_before = false;
-                } else {
-                    flags.ternary_depth -= 1;
-                }
-            } else if (current_token.text === '?') {
-                flags.ternary_depth += 1;
-            } else if (current_token.text === '*' && last_type === 'TK_RESERVED' && flags.last_text === 'function') {
+            } else if (isGeneratorAsterisk) {
                 space_before = false;
                 space_after = false;
             }
@@ -1259,12 +1404,10 @@
 
         function handle_block_comment() {
             if (output.raw) {
-                output.add_raw_token(current_token)
-                if (current_token.directives && current_token.directives['preserve'] === 'end') {
+                output.add_raw_token(current_token);
+                if (current_token.directives && current_token.directives.preserve === 'end') {
                     // If we're testing the raw output behavior, do not allow a directive to turn it off.
-                    if (!opt.test_output_raw) {
-                        output.raw = false;
-                    }
+                    output.raw = opt.test_output_raw;
                 }
                 return;
             }
@@ -1272,7 +1415,7 @@
             if (current_token.directives) {
                 print_newline(false, true);
                 print_token();
-                if (current_token.directives['preserve'] === 'start') {
+                if (current_token.directives.preserve === 'start') {
                     output.raw = true;
                 }
                 print_newline(false, true);
@@ -1297,12 +1440,8 @@
             // block comment starts with a new line
             print_newline(false, true);
             if (lines.length > 1) {
-                if (all_lines_start_with(lines.slice(1), '*')) {
-                    javadoc = true;
-                }
-                else if (each_line_matches_indent(lines.slice(1), lastIndent)) {
-                    starless = true;
-                }
+                javadoc = all_lines_start_with(lines.slice(1), '*');
+                starless = each_line_matches_indent(lines.slice(1), lastIndent);
             }
 
             // first line always indented
@@ -1379,31 +1518,31 @@
         var _empty = true;
 
         this.set_indent = function(level) {
-            _character_count = parent.baseIndentLength + level * parent.indent_length
+            _character_count = parent.baseIndentLength + level * parent.indent_length;
             _indent_count = level;
-        }
+        };
 
         this.get_character_count = function() {
             return _character_count;
-        }
+        };
 
         this.is_empty = function() {
             return _empty;
-        }
+        };
 
         this.last = function() {
             if (!this._empty) {
-              return _items[_items.length - 1];
+                return _items[_items.length - 1];
             } else {
-              return null;
+                return null;
             }
-        }
+        };
 
         this.push = function(input) {
             _items.push(input);
             _character_count += input.length;
             _empty = false;
-        }
+        };
 
         this.pop = function() {
             var item = null;
@@ -1413,22 +1552,22 @@
                 _empty = _items.length === 0;
             }
             return item;
-        }
+        };
 
         this.remove_indent = function() {
             if (_indent_count > 0) {
                 _indent_count -= 1;
-                _character_count -= parent.indent_length
+                _character_count -= parent.indent_length;
             }
-        }
+        };
 
         this.trim = function() {
             while (this.last() === ' ') {
-                var item = _items.pop();
+                _items.pop();
                 _character_count -= 1;
             }
             _empty = _items.length === 0;
-        }
+        };
 
         this.toString = function() {
             var result = '';
@@ -1436,20 +1575,20 @@
                 if (_indent_count >= 0) {
                     result = parent.indent_cache[_indent_count];
                 }
-                result += _items.join('')
+                result += _items.join('');
             }
             return result;
-        }
+        };
     }
 
     function Output(indent_string, baseIndentString) {
         baseIndentString = baseIndentString || '';
-        this.indent_cache = [ baseIndentString ];
+        this.indent_cache = [baseIndentString];
         this.baseIndentLength = baseIndentString.length;
         this.indent_length = indent_string.length;
         this.raw = false;
 
-        var lines =[];
+        var lines = [];
         this.baseIndentString = baseIndentString;
         this.indent_string = indent_string;
         this.previous_line = null;
@@ -1460,7 +1599,7 @@
             this.previous_line = this.current_line;
             this.current_line = new OutputLine(this);
             lines.push(this.current_line);
-        }
+        };
 
         // initialize
         this.add_outputline();
@@ -1468,7 +1607,7 @@
 
         this.get_line_number = function() {
             return lines.length;
-        }
+        };
 
         // Using object instead of string to allow for later expansion of info about each line
         this.add_new_line = function(force_newline) {
@@ -1484,17 +1623,17 @@
             }
 
             return false;
-        }
+        };
 
         this.get_code = function() {
             var sweet_code = lines.join('\n').replace(/[\r\n\t ]+$/, '');
             return sweet_code;
-        }
+        };
 
         this.set_indent = function(level) {
             // Never indent your first output indent at the start of the file
             if (lines.length > 1) {
-                while(level >= this.indent_cache.length) {
+                while (level >= this.indent_cache.length) {
                     this.indent_cache.push(this.indent_cache[this.indent_cache.length - 1] + this.indent_string);
                 }
 
@@ -1503,7 +1642,7 @@
             }
             this.current_line.set_indent(0);
             return false;
-        }
+        };
 
         this.add_raw_token = function(token) {
             for (var x = 0; x < token.newlines; x++) {
@@ -1512,21 +1651,21 @@
             this.current_line.push(token.whitespace_before);
             this.current_line.push(token.text);
             this.space_before_token = false;
-        }
+        };
 
         this.add_token = function(printable_token) {
             this.add_space_before_token();
             this.current_line.push(printable_token);
-        }
+        };
 
         this.add_space_before_token = function() {
             if (this.space_before_token && !this.just_added_newline()) {
                 this.current_line.push(' ');
             }
             this.space_before_token = false;
-        }
+        };
 
-        this.remove_redundant_indentation = function (frame) {
+        this.remove_redundant_indentation = function(frame) {
             // This implementation is effective but has some issues:
             //     - can cause line wrap to happen too soon due to indent removal
             //           after wrap points are calculated
@@ -1540,14 +1679,13 @@
 
             // remove one indent from each line inside this section
             var index = frame.start_line_index;
-            var line;
 
             var output_length = lines.length;
             while (index < output_length) {
                 lines[index].remove_indent();
                 index++;
             }
-        }
+        };
 
         this.trim = function(eat_newlines) {
             eat_newlines = (eat_newlines === undefined) ? false : eat_newlines;
@@ -1557,16 +1695,16 @@
             while (eat_newlines && lines.length > 1 &&
                 this.current_line.is_empty()) {
                 lines.pop();
-                this.current_line = lines[lines.length - 1]
+                this.current_line = lines[lines.length - 1];
                 this.current_line.trim();
             }
 
             this.previous_line = lines.length > 1 ? lines[lines.length - 2] : null;
-        }
+        };
 
         this.just_added_newline = function() {
             return this.current_line.is_empty();
-        }
+        };
 
         this.just_added_blankline = function() {
             if (this.just_added_newline()) {
@@ -1578,23 +1716,23 @@
                 return line.is_empty();
             }
             return false;
-        }
+        };
     }
 
 
-    var Token = function(type, text, newlines, whitespace_before, mode, parent) {
+    var Token = function(type, text, newlines, whitespace_before, parent) {
         this.type = type;
         this.text = text;
         this.comments_before = [];
         this.newlines = newlines || 0;
         this.wanted_newline = newlines > 0;
         this.whitespace_before = whitespace_before || '';
-        this.parent = null;
+        this.parent = parent || null;
         this.opened = null;
         this.directives = null;
-    }
+    };
 
-    function tokenizer(input, opts, indent_string) {
+    function tokenizer(input, opts) {
 
         var whitespace = "\n\r\t ".split('');
         var digit = /[0-9]/;
@@ -1602,10 +1740,14 @@
         var digit_oct = /[01234567]/;
         var digit_hex = /[0123456789abcdefABCDEF]/;
 
-        var punct = ('+ - * / % & ++ -- = += -= *= /= %= == === != !== > < >= <= >> << >>> >>>= >>= <<= && &= | || ! ~ , : ? ^ ^= |= :: => **').split(' ');
+        this.positionable_operators = '!= !== % & && * ** + - / : < << <= == === > >= >> >>> ? ^ | ||'.split(' ');
+        var punct = this.positionable_operators.concat(
+            // non-positionable operators - these do not follow operator position settings
+            '! %= &= *= **= ++ += , -- -= /= :: <<= = => >>= >>>= ^= |= ~'.split(' '));
+
         // words which should always start on new line.
         this.line_starters = 'continue,try,throw,return,var,let,const,if,switch,case,default,for,while,break,function,import,export'.split(',');
-        var reserved_words = this.line_starters.concat(['do', 'in', 'else', 'get', 'set', 'new', 'catch', 'finally', 'typeof', 'yield', 'async', 'await', 'from']);
+        var reserved_words = this.line_starters.concat(['do', 'in', 'else', 'get', 'set', 'new', 'catch', 'finally', 'typeof', 'yield', 'async', 'await', 'from', 'as']);
 
         //  /* ... */ comment ends with nearest */ or end of file
         var block_comment_pattern = /([\s\S]*?)((?:\*\/)|$)/g;
@@ -1617,16 +1759,16 @@
         var directive_pattern = / (\w+)[:](\w+)/g;
         var directives_end_ignore_pattern = /([\s\S]*?)((?:\/\*\sbeautify\signore:end\s\*\/)|$)/g;
 
-        var template_pattern = /((<\?php|<\?=)[\s\S]*?\?>)|(<%[\s\S]*?%>)/g
+        var template_pattern = /((<\?php|<\?=)[\s\S]*?\?>)|(<%[\s\S]*?%>)/g;
 
         var n_newlines, whitespace_before_token, in_html_comment, tokens, parser_pos;
         var input_length;
 
         this.tokenize = function() {
             // cache the source's length.
-            input_length = input.length
+            input_length = input.length;
             parser_pos = 0;
-            in_html_comment = false
+            in_html_comment = false;
             tokens = [];
 
             var next, last;
@@ -1638,7 +1780,7 @@
             while (!(last && last.type === 'TK_EOF')) {
                 token_values = tokenize_next();
                 next = new Token(token_values[1], token_values[0], n_newlines, whitespace_before_token);
-                while(next.type === 'TK_COMMENT' || next.type === 'TK_BLOCK_COMMENT' || next.type === 'TK_UNKNOWN') {
+                while (next.type === 'TK_COMMENT' || next.type === 'TK_BLOCK_COMMENT' || next.type === 'TK_UNKNOWN') {
                     if (next.type === 'TK_BLOCK_COMMENT') {
                         next.directives = token_values[2];
                     }
@@ -1656,13 +1798,13 @@
                     next.parent = last;
                     open_stack.push(open);
                     open = next;
-                }  else if ((next.type === 'TK_END_BLOCK' || next.type === 'TK_END_EXPR') &&
+                } else if ((next.type === 'TK_END_BLOCK' || next.type === 'TK_END_EXPR') &&
                     (open && (
                         (next.text === ']' && open.text === '[') ||
                         (next.text === ')' && open.text === '(') ||
                         (next.text === '}' && open.text === '{')))) {
                     next.parent = open.parent;
-                    next.opened = open
+                    next.opened = open;
 
                     open = open_stack.pop();
                 }
@@ -1672,9 +1814,9 @@
             }
 
             return tokens;
-        }
+        };
 
-        function get_directives (text) {
+        function get_directives(text) {
             if (!text.match(directives_block_pattern)) {
                 return null;
             }
@@ -1692,7 +1834,7 @@
         }
 
         function tokenize_next() {
-            var i, resulting_string;
+            var resulting_string;
             var whitespace_on_this_line = [];
 
             n_newlines = 0;
@@ -1704,7 +1846,7 @@
 
             var last_token;
             if (tokens.length) {
-                last_token = tokens[tokens.length-1];
+                last_token = tokens[tokens.length - 1];
             } else {
                 // For the sake of tokenizing we can pretend that there was on open brace to start
                 last_token = new Token('TK_START_BLOCK', '{');
@@ -1717,7 +1859,7 @@
             while (in_array(c, whitespace)) {
 
                 if (acorn.newline.test(c)) {
-                    if (!(c === '\n' && input.charAt(parser_pos-2) === '\r')) {
+                    if (!(c === '\n' && input.charAt(parser_pos - 2) === '\r')) {
                         n_newlines += 1;
                         whitespace_on_this_line = [];
                     }
@@ -1733,7 +1875,7 @@
                 parser_pos += 1;
             }
 
-            if(whitespace_on_this_line.length) {
+            if (whitespace_on_this_line.length) {
                 whitespace_before_token = whitespace_on_this_line.join('');
             }
 
@@ -1746,9 +1888,9 @@
                     // switch to hex/oct/bin number, no decimal or e, just hex/oct/bin digits
                     allow_decimal = false;
                     allow_e = false;
-                    if ( /[Bb]/.test(input.charAt(parser_pos)) ) {
+                    if (/[Bb]/.test(input.charAt(parser_pos))) {
                         local_digit = digit_bin;
-                    } else if ( /[Oo]/.test(input.charAt(parser_pos)) ) {
+                    } else if (/[Oo]/.test(input.charAt(parser_pos))) {
                         local_digit = digit_oct;
                     } else {
                         local_digit = digit_hex;
@@ -1790,7 +1932,7 @@
                 return [c, 'TK_WORD'];
             }
 
-            if (acorn.isIdentifierStart(input.charCodeAt(parser_pos-1))) {
+            if (acorn.isIdentifierStart(input.charCodeAt(parser_pos - 1))) {
                 if (parser_pos < input_length) {
                     while (acorn.isIdentifierChar(input.charCodeAt(parser_pos))) {
                         c += input.charAt(parser_pos);
@@ -1802,8 +1944,8 @@
                 }
 
                 if (!(last_token.type === 'TK_DOT' ||
-                        (last_token.type === 'TK_RESERVED' && in_array(last_token.text, ['set', 'get'])))
-                    && in_array(c, reserved_words)) {
+                        (last_token.type === 'TK_RESERVED' && in_array(last_token.text, ['set', 'get']))) &&
+                    in_array(c, reserved_words)) {
                     if (c === 'in') { // hack for 'in' operator
                         return [c, 'TK_OPERATOR'];
                     }
@@ -1835,17 +1977,18 @@
 
             if (c === '/') {
                 var comment = '';
+                var comment_match;
                 // peek for comment /* ... */
                 if (input.charAt(parser_pos) === '*') {
                     parser_pos += 1;
                     block_comment_pattern.lastIndex = parser_pos;
-                    var comment_match = block_comment_pattern.exec(input);
+                    comment_match = block_comment_pattern.exec(input);
                     comment = '/*' + comment_match[0];
                     parser_pos += comment_match[0].length;
                     var directives = get_directives(comment);
-                    if (directives && directives['ignore'] === 'start') {
+                    if (directives && directives.ignore === 'start') {
                         directives_end_ignore_pattern.lastIndex = parser_pos;
-                        comment_match = directives_end_ignore_pattern.exec(input)
+                        comment_match = directives_end_ignore_pattern.exec(input);
                         comment += comment_match[0];
                         parser_pos += comment_match[0].length;
                     }
@@ -1856,7 +1999,7 @@
                 if (input.charAt(parser_pos) === '/') {
                     parser_pos += 1;
                     comment_pattern.lastIndex = parser_pos;
-                    var comment_match = comment_pattern.exec(input);
+                    comment_match = comment_pattern.exec(input);
                     comment = '//' + comment_match[0];
                     parser_pos += comment_match[0].length;
                     return [comment, 'TK_COMMENT'];
@@ -1864,14 +2007,14 @@
 
             }
 
-            var startXmlRegExp = /^<([-a-zA-Z:0-9_.]+|{.+?}|!\[CDATA\[[\s\S]*?\]\])(\s+{.+?}|\s+[-a-zA-Z:0-9_.]+|\s+[-a-zA-Z:0-9_.]+\s*=\s*('[^']*'|"[^"]*"|{.+?}))*\s*(\/?)\s*>/
+            var startXmlRegExp = /^<([-a-zA-Z:0-9_.]+|{.+?}|!\[CDATA\[[\s\S]*?\]\])(\s+{.+?}|\s+[-a-zA-Z:0-9_.]+|\s+[-a-zA-Z:0-9_.]+\s*=\s*('[^']*'|"[^"]*"|{.+?}))*\s*(\/?)\s*>/;
 
             if (c === '`' || c === "'" || c === '"' || // string
                 (
                     (c === '/') || // regexp
                     (opts.e4x && c === "<" && input.slice(parser_pos - 1).match(startXmlRegExp)) // xml
                 ) && ( // regex and xml can only appear in specific locations during parsing
-                    (last_token.type === 'TK_RESERVED' && in_array(last_token.text , ['return', 'case', 'throw', 'else', 'do', 'typeof', 'yield'])) ||
+                    (last_token.type === 'TK_RESERVED' && in_array(last_token.text, ['return', 'case', 'throw', 'else', 'do', 'typeof', 'yield'])) ||
                     (last_token.type === 'TK_END_EXPR' && last_token.text === ')' &&
                         last_token.parent && last_token.parent.type === 'TK_RESERVED' && in_array(last_token.parent.text, ['if', 'while', 'for'])) ||
                     (in_array(last_token.type, ['TK_COMMENT', 'TK_START_EXPR', 'TK_START_BLOCK',
@@ -1891,7 +2034,7 @@
                     //
                     var in_char_class = false;
                     while (parser_pos < input_length &&
-                            ((esc || in_char_class || input.charAt(parser_pos) !== sep) &&
+                        ((esc || in_char_class || input.charAt(parser_pos) !== sep) &&
                             !acorn.newline.test(input.charAt(parser_pos)))) {
                         resulting_string += input.charAt(parser_pos);
                         if (!esc) {
@@ -1918,9 +2061,9 @@
                         var rootTag = match[2];
                         var depth = 0;
                         while (match) {
-                            var isEndTag = !! match[1];
+                            var isEndTag = !!match[1];
                             var tagName = match[2];
-                            var isSingletonTag = ( !! match[match.length - 1]) || (tagName.slice(0, 8) === "![CDATA[");
+                            var isSingletonTag = (!!match[match.length - 1]) || (tagName.slice(0, 8) === "![CDATA[");
                             if (tagName === rootTag && !isSingletonTag) {
                                 if (isEndTag) {
                                     --depth;
@@ -1950,7 +2093,7 @@
                         while (parser_pos < input_length) {
                             current_char = input.charAt(parser_pos);
                             if (!(esc || (current_char !== delimiter &&
-                                (allow_unescaped_newlines || !acorn.newline.test(current_char))))) {
+                                    (allow_unescaped_newlines || !acorn.newline.test(current_char))))) {
                                 break;
                             }
 
@@ -1977,17 +2120,18 @@
 
                             if (start_sub && resulting_string.indexOf(start_sub, resulting_string.length - start_sub.length) !== -1) {
                                 if (delimiter === '`') {
-                                    parse_string('}', allow_unescaped_newlines, '`')
-                                }  else {
-                                    parse_string('`', allow_unescaped_newlines, '${')
+                                    parse_string('}', allow_unescaped_newlines, '`');
+                                } else {
+                                    parse_string('`', allow_unescaped_newlines, '${');
                                 }
                             }
                         }
-                    }
+                    };
+
                     if (sep === '`') {
-                        parse_string('`', true, '${')
-                    }  else {
-                        parse_string(sep)
+                        parse_string('`', true, '${');
+                    } else {
+                        parse_string(sep);
                     }
                 }
 
@@ -2052,7 +2196,7 @@
             if (c === '<' && (input.charAt(parser_pos) === '?' || input.charAt(parser_pos) === '%')) {
                 template_pattern.lastIndex = parser_pos - 1;
                 var template_match = template_pattern.exec(input);
-                if(template_match) {
+                if (template_match) {
                     c = template_match[0];
                     parser_pos += c.length - 1;
                     c = c.replace(acorn.allLineBreaks, '\n');
@@ -2166,7 +2310,6 @@
             }
             return out;
         }
-
     }
 
 


### PR DESCRIPTION
I fixed this bug: brackets-beautify#182
I added the code unfolding before replacing.

"Ctrl+A -> Beautify" mode …
If you selected all the text in the file, it is necessary to maintain the same behavior as for all the text (when there is no text selection)