### PR TITLE
Updated the broken package.json, works now.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
             "description": "Formato JavaScript, HTML e file CSS e linguaggi affini."
         },
         "zh-cn": {
-            "description": "格式化JavaScript, HTML, CSS文件以及相关的语言。",
-        },
+            "description": "格式化JavaScript, HTML, CSS文件以及相关的语言。"
+        }
     }
 }


### PR DESCRIPTION
I tried to install the extension into my Brackets, but an error occurred. I looked for the error and found it in the package. json. At the end of the file were two superfluous commas, which I removed. After that I was able to install the extension.